### PR TITLE
Add permission to read content to "Publish Test Results" job

### DIFF
--- a/.github/workflows/test-result.yml
+++ b/.github/workflows/test-result.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       actions: read
       checks: write
+      contents: read
       pull-requests: write
 
     steps:


### PR DESCRIPTION
Add permission to read content to "Publish Test Results" workflow job. Also, upgrade publish-unit-test-result-action to v2.10.0.