### PR TITLE
Upgrade actions/cache, actions/checkout, and actions/setup-java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Maven dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-mvn-deps
         with:
@@ -44,9 +44,11 @@ jobs:
             ${{ runner.os }}-
 
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.13.0
         with:
+          distribution: 'temurin'
           java-version: 17
+          java-package: jdk
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD


### PR DESCRIPTION
Upgrade actions/cache, actions/checkout, and actions/setup-java to versions 3, 4, and 3.13.0
