### PR TITLE
Fix bug with section start line when there is no grammar declaration

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -516,8 +516,9 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
     {
         String sourceId = sectionState.getDocumentState().getDocumentId();
         GrammarSection section = sectionState.getSection();
-        SourceInformation sectionSourceInfo = new SourceInformation(sourceId, section.getStartLine(), 0, section.getEndLine(), section.getLineLength(section.getEndLine()));
-        ParseTreeWalkerSourceInformation walkerSourceInfo = new ParseTreeWalkerSourceInformation.Builder(sourceId, section.getStartLine(), 0).build();
+        int startLine = section.hasGrammarDeclaration() ? (section.getStartLine() + 1) : section.getStartLine();
+        SourceInformation sectionSourceInfo = new SourceInformation(sourceId, startLine, 0, section.getEndLine(), section.getLineLength(section.getEndLine()));
+        ParseTreeWalkerSourceInformation walkerSourceInfo = new ParseTreeWalkerSourceInformation.Builder(sourceId, startLine, 0).build();
         return new SectionSourceCode(section.getText(true), section.getGrammar(), sectionSourceInfo, walkerSourceInfo);
     }
 
@@ -538,7 +539,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
     protected static boolean isValidSourceInfo(SourceInformation sourceInfo)
     {
         return (sourceInfo != null) &&
-                (sourceInfo.startLine >= 0) &&
+                (sourceInfo.startLine > 0) &&
                 (sourceInfo.startColumn > 0) &&
                 (sourceInfo.startLine <= sourceInfo.endLine) &&
                 ((sourceInfo.startLine == sourceInfo.endLine) ? (sourceInfo.startColumn <= sourceInfo.endColumn) : (sourceInfo.endColumn > 0));
@@ -552,7 +553,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
      */
     protected static TextInterval toLocation(SourceInformation sourceInfo)
     {
-        return TextInterval.newInterval(sourceInfo.startLine, sourceInfo.startColumn - 1, sourceInfo.endLine, sourceInfo.endColumn - 1);
+        return TextInterval.newInterval(sourceInfo.startLine - 1, sourceInfo.startColumn - 1, sourceInfo.endLine - 1, sourceInfo.endColumn - 1);
     }
 
     protected static class Result<T>

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestPureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestPureLSPGrammarExtension.java
@@ -36,6 +36,53 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
     public void testGetDeclarations()
     {
         testGetDeclarations(
+                "Class test::model::TestClass1\n" +
+                        "{\r\n" +
+                        "}\n" +
+                        "\n" +
+                        "\r\n" +
+                        "Enum test::model::TestEnumeration\n" +
+                        "{\n" +
+                        "  VAL1, VAL2,\n" +
+                        "  VAL3, VAL4\r\n" +
+                        "}\n" +
+                        "\r\n" +
+                        "Profile test::model::TestProfile\n" +
+                        "{\n" +
+                        "  stereotypes: [st1, st2];\n" +
+                        "  tags: [tag1, tag2, tag3];\n" +
+                        "}\n" +
+                        "\r\n" +
+                        "Class test::model::TestClass2\n" +
+                        "{\n" +
+                        "   name : String[1];\n" +
+                        "   type : test::model::TestEnumeration[1];\n" +
+                        "}\n" +
+                        "\r\n" +
+                        "Association test::model::TestAssociation\n" +
+                        "{\n" +
+                        "   oneToTwo : test::model::TestClass2[*];\n" +
+                        "   twoToOne : test::model::TestClass1[*];\n" +
+                        "}\n",
+                LegendDeclaration.builder().withIdentifier("test::model::TestClass1").withClassifier(M3Paths.Class).withLocation(0, 0, 2, 0).build(),
+                LegendDeclaration.builder().withIdentifier("test::model::TestEnumeration").withClassifier(M3Paths.Enumeration).withLocation(5, 0, 9, 0)
+                        .withChild(LegendDeclaration.builder().withIdentifier("VAL1").withClassifier("test::model::TestEnumeration").withLocation(7, 2, 7, 5).build())
+                        .withChild(LegendDeclaration.builder().withIdentifier("VAL2").withClassifier("test::model::TestEnumeration").withLocation(7, 8, 7, 11).build())
+                        .withChild(LegendDeclaration.builder().withIdentifier("VAL3").withClassifier("test::model::TestEnumeration").withLocation(8, 2, 8, 5).build())
+                        .withChild(LegendDeclaration.builder().withIdentifier("VAL4").withClassifier("test::model::TestEnumeration").withLocation(8, 8, 8, 11).build())
+                        .build(),
+                LegendDeclaration.builder().withIdentifier("test::model::TestProfile").withClassifier(M3Paths.Profile).withLocation(11, 0, 15, 0).build(),
+                LegendDeclaration.builder().withIdentifier("test::model::TestClass2").withClassifier(M3Paths.Class).withLocation(17, 0, 21, 0)
+                        .withChild(LegendDeclaration.builder().withIdentifier("name").withClassifier(M3Paths.Property).withLocation(19, 3, 19, 19).build())
+                        .withChild(LegendDeclaration.builder().withIdentifier("type").withClassifier(M3Paths.Property).withLocation(20, 3, 20, 41).build())
+                        .build(),
+                LegendDeclaration.builder().withIdentifier("test::model::TestAssociation").withClassifier(M3Paths.Association).withLocation(23, 0, 27, 0)
+                        .withChild(LegendDeclaration.builder().withIdentifier("oneToTwo").withClassifier(M3Paths.Property).withLocation(25, 3, 25, 40).build())
+                        .withChild(LegendDeclaration.builder().withIdentifier("twoToOne").withClassifier(M3Paths.Property).withLocation(26, 3, 26, 40).build())
+                        .build()
+        );
+
+        testGetDeclarations(
                 "###Pure\n" +
                         "\r\n" +
                         "Class test::model::TestClass1\n" +

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
@@ -269,7 +269,7 @@ class LegendTextDocumentService implements TextDocumentService
                         if (!keywords.isEmpty())
                         {
                             Pattern pattern = Pattern.compile("(?<!\\w)(" + String.join("|", keywords) + ")(?!\\w)");
-                            int startLine = Math.max(section.getStartLine(), rangeStartLine);
+                            int startLine = Math.max(section.hasGrammarDeclaration() ? (section.getStartLine() + 1) : section.getStartLine(), rangeStartLine);
                             int endLine = Math.min(section.getEndLine(), isRangeEndLineInclusive ? rangeEndLine : (rangeEndLine - 1));
                             for (int n = startLine; n <= endLine; n++)
                             {


### PR DESCRIPTION
Fix bug with section start line when there is no grammar declaration. When getting the start line of a section for diagnostics and keywords, the server needs to take into account whether there is an explicit grammar line.