### PR TITLE
Rename sourceIds to ids in LegendExecutionResult, and add validations

### DIFF
--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/execution/LegendExecutionResult.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/execution/LegendExecutionResult.java
@@ -23,17 +23,33 @@ import java.util.Objects;
  */
 public class LegendExecutionResult
 {
+    private final List<String> ids;
     private final Type type;
     private final String message;
     private final String logMessage;
-    private final List<String> sourceIds;
 
-    private LegendExecutionResult(List<String> sourceIds, Type type, String message, String logMessage)
+    private LegendExecutionResult(List<String> ids, Type type, String message, String logMessage)
     {
-        this.sourceIds = Objects.requireNonNull(sourceIds, "sourceIds is required");
+        Objects.requireNonNull(ids, "ids may not be null").forEach(id -> Objects.requireNonNull(id, "id may not be null"));
+        if (ids.isEmpty())
+        {
+            throw new IllegalArgumentException("ids may not be empty");
+        }
+        this.ids = ids;
         this.type = Objects.requireNonNull(type, "type is required");
         this.message = Objects.requireNonNull(message, "message is required");
         this.logMessage = logMessage;
+    }
+
+    /**
+     * Get the result ids. These should be understood hierarchically. For example, the list could consist of an entity
+     * path, a test suite id, and a test id.
+     *
+     * @return result ids
+     */
+    public List<String> getIds()
+    {
+        return this.ids;
     }
 
     /**
@@ -66,11 +82,6 @@ public class LegendExecutionResult
         return this.logMessage;
     }
 
-    public List<String> getSourceIds()
-    {
-        return this.sourceIds;
-    }
-
     /**
      * Return the log message if present. If not present, then the result message will be returned if
      * {@code returnMessageIfAbsent} is true and null if it is false.
@@ -83,58 +94,97 @@ public class LegendExecutionResult
         return ((this.logMessage == null) && returnMessageIfAbsent) ? this.message : this.logMessage;
     }
 
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other)
+        {
+            return true;
+        }
+
+        if (!(other instanceof LegendExecutionResult))
+        {
+            return false;
+        }
+
+        LegendExecutionResult that = (LegendExecutionResult) other;
+        return (this.type == that.type) &&
+                this.message.equals(that.message) &&
+                Objects.equals(this.logMessage, that.logMessage) &&
+                this.ids.equals(that.ids);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(this.ids, this.type, this.message, this.logMessage);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder(getClass().getSimpleName()).append('{');
+        if (!this.ids.isEmpty())
+        {
+            int start = builder.length();
+            this.ids.forEach(id -> ((builder.length() == start) ? builder.append("ids=[\"") : builder.append("\", \"")).append(id));
+            builder.append("] ");
+        }
+        return builder.append("type=").append(this.type).append('}').toString();
+    }
+
     /**
      * Construct a new Legend execution result.
      *
-     * @param sourceIds     result sourceIds
+     * @param ids        result ids
      * @param type       result type
      * @param message    result message
      * @param logMessage log message (optional)
      * @return execution result
      */
-    public static LegendExecutionResult newResult(List<String> sourceIds, Type type, String message, String logMessage)
+    public static LegendExecutionResult newResult(List<String> ids, Type type, String message, String logMessage)
     {
-        return new LegendExecutionResult(sourceIds, type, message, logMessage);
+        return new LegendExecutionResult(ids, type, message, logMessage);
     }
 
     /**
      * Construct a new Legend execution result.
      *
-     * @param entityPath  result entityPath
+     * @param id         result id
      * @param type       result type
      * @param message    result message
      * @param logMessage log message (optional)
      * @return execution result
      */
-    public static LegendExecutionResult newResult(String entityPath, Type type, String message, String logMessage)
+    public static LegendExecutionResult newResult(String id, Type type, String message, String logMessage)
     {
-        return new LegendExecutionResult(Collections.singletonList(entityPath), type, message, logMessage);
+        return newResult(Collections.singletonList(id), type, message, logMessage);
     }
 
     /**
      * Construct a new Legend execution result.
      *
-     * @param sourceIds result sourceIds
+     * @param ids     result ids
      * @param type    result type
      * @param message result message
      * @return execution result
      */
-    public static LegendExecutionResult newResult(List<String> sourceIds, Type type, String message)
+    public static LegendExecutionResult newResult(List<String> ids, Type type, String message)
     {
-        return newResult(sourceIds, type, message, null);
+        return newResult(ids, type, message, null);
     }
 
     /**
      * Construct a new Legend execution result.
      *
-     * @param entityPath  result entityPath
+     * @param id      result id
      * @param type    result type
      * @param message result message
      * @return execution result
      */
-    public static LegendExecutionResult newResult(String entityPath, Type type, String message)
+    public static LegendExecutionResult newResult(String id, Type type, String message)
     {
-        return newResult(Collections.singletonList(entityPath), type, message, null);
+        return newResult(id, type, message, null);
     }
 
     public enum Type


### PR DESCRIPTION
Rename sourceIds to ids in LegendExecutionResult. Add validations to ensure that the id list is non-null, non-empty, and contains no null values.