### PR TITLE
Changing email & url in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a Vulnerability
 
-To report a vulnerability please send an email with the details to <help@finos.org>. This will help us to assess the risk and start the necessary steps. For more details, please refer to our [reporting security and vulnerabilities disclosure policy](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/1230176257/Security+Vulnerabilities+Responsible+Disclosure+Policy).
+To report a vulnerability please send an email with the details to <security@finos.org>. This will help us to assess the risk and start the necessary steps. For more details, please refer to our [reporting security and vulnerabilities disclosure policy](https://community.finos.org/docs/governance/software-projects/cve-responsible-disclosure/).
 
 Thanks for helping to keep our product secure.


### PR DESCRIPTION
Changing email from help@finos.org to security@finos.org and the url who redirected to the wrong address.