### PR TITLE
Reduce shaded jar size by managing runtime dependencies using maven

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/pom.xml
+++ b/legend-engine-ide-lsp-default-extensions/pom.xml
@@ -121,10 +121,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-generation</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestConnectionLSPGrammarExtension.java
@@ -27,7 +27,6 @@ import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
-import org.finos.legend.engine.plan.execution.stores.relational.connection.api.schema.model.DatabaseBuilderInput;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.junit.jupiter.api.Assertions;
@@ -94,7 +93,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
                 ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
                 try
                 {
-                    DatabaseBuilderInput body = objectMapper.readValue(exchange.getRequestBody(), DatabaseBuilderInput.class);
+                    ConnectionLSPGrammarExtension.DatabaseBuilderInput body = objectMapper.readValue(exchange.getRequestBody(), ConnectionLSPGrammarExtension.DatabaseBuilderInput.class);
                     Assertions.assertEquals("model::MyStore", body.connection.element);
                     Assertions.assertEquals("model", body.targetDatabase._package);
                     Assertions.assertEquals("MyConnectionDatabase", body.targetDatabase.name);

--- a/legend-engine-ide-lsp-server-shaded/pom.xml
+++ b/legend-engine-ide-lsp-server-shaded/pom.xml
@@ -71,12 +71,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.finos.legend.engine.ide.lsp</groupId>
-            <artifactId>legend-engine-ide-lsp-default-extensions</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>runtime</scope>

--- a/legend-engine-ide-lsp-server/pom.xml
+++ b/legend-engine-ide-lsp-server/pom.xml
@@ -43,6 +43,31 @@
         <!-- LEGEND ENGINE LSP -->
 
         <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+        </dependency>
+        
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathFactory.java
@@ -1,0 +1,22 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.classpath;
+
+import org.eclipse.lsp4j.WorkspaceFolder;
+
+public interface ClasspathFactory
+{
+    ClassLoader create(Iterable<? extends WorkspaceFolder> folders);
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
@@ -1,0 +1,156 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.classpath;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.InvokerLogger;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.apache.maven.shared.invoker.PrintStreamHandler;
+import org.apache.maven.shared.invoker.PrintStreamLogger;
+import org.apache.maven.shared.utils.Os;
+import org.apache.maven.shared.utils.cli.CommandLineUtils;
+import org.apache.maven.shared.utils.cli.Commandline;
+import org.eclipse.collections.impl.block.factory.Functions;
+import org.eclipse.lsp4j.WorkspaceFolder;
+
+public class ClasspathUsingMavenFactory implements ClasspathFactory
+{
+    private final Invoker invoker;
+    private final File defaultPom;
+    private final ByteArrayOutputStream outputStream;
+
+    public ClasspathUsingMavenFactory(File defaultPom)
+    {
+        this.defaultPom = defaultPom;
+        this.invoker = new DefaultInvoker();
+        this.outputStream = new ByteArrayOutputStream();
+        this.invoker.setLogger(new PrintStreamLogger(new PrintStream(this.outputStream, true), InvokerLogger.INFO));
+
+        configureMvnExecIfPossible(this.invoker);
+    }
+
+    private static void configureMvnExecIfPossible(Invoker invoker)
+    {
+        if (System.getProperty("maven.home") == null)
+        {
+            Commandline commandline = new Commandline();
+
+            if (Os.isFamily(Os.FAMILY_WINDOWS))
+            {
+                commandline.setExecutable("where");
+                commandline.addArguments("mvn");
+            }
+            else if (Os.isFamily(Os.FAMILY_UNIX))
+            {
+                commandline.setExecutable("which");
+                commandline.addArguments("mvn");
+            }
+            else
+            {
+                throw new UnsupportedOperationException("OS not supported");
+            }
+
+            CommandLineUtils.StringStreamConsumer systemOut = new CommandLineUtils.StringStreamConsumer();
+            CommandLineUtils.StringStreamConsumer systemErr = new CommandLineUtils.StringStreamConsumer();
+            int result;
+
+            try
+            {
+                result = CommandLineUtils.executeCommandLine(commandline, systemOut, systemErr, 2);
+            }
+            catch (Exception e)
+            {
+                result = -1;
+            }
+
+            if (result == 0)
+            {
+                String location = systemOut.getOutput().split(System.lineSeparator())[0];
+                invoker.setMavenExecutable(new File(location));
+            }
+        }
+        else
+        {
+            invoker.setMavenHome(new File(System.getProperty("maven.home")));
+        }
+    }
+
+    @Override
+    public ClassLoader create(Iterable<? extends WorkspaceFolder> folders)
+    {
+        try
+        {
+            File pom = this.defaultPom;
+
+            // todo apply properties from /project.json is this exists...
+            // todo if project.json exists, use pom from a sub-module
+            // todo otherwise, check if pom exists on root
+            // todo last, use a default pom...
+
+            File legendLspClasspath = File.createTempFile("legend_lsp_classpath", ".txt");
+            legendLspClasspath.deleteOnExit();
+
+            Properties properties = new Properties();
+            properties.setProperty("mdep.outputFile", legendLspClasspath.getAbsolutePath());
+
+            InvocationRequest request = new DefaultInvocationRequest();
+            request.setPomFile(pom);
+            request.setOutputHandler(new PrintStreamHandler(new PrintStream(this.outputStream, true), true));
+            request.setGoals(Collections.singletonList("dependency:build-classpath"));
+            request.setProperties(properties);
+            request.setTimeoutInSeconds((int) TimeUnit.MINUTES.toSeconds(5));
+            request.setJavaHome(Optional.ofNullable(System.getProperty("java.home")).map(File::new).orElse(null));
+
+            InvocationResult result = this.invoker.execute(request);
+            if (result.getExitCode() != 0)
+            {
+                String output = this.outputStream.toString(StandardCharsets.UTF_8);
+                throw new IllegalStateException("Maven invoker failed\n\n" + output, result.getExecutionException());
+            }
+
+            String classpath = FileUtils.readFileToString(legendLspClasspath, StandardCharsets.UTF_8);
+            String[] classpathEntries = classpath.split(";");
+            URL[] urls = Stream.of(classpathEntries).map(Functions.throwing(x -> new File(x).toURI().toURL())).toArray(URL[]::new);
+
+            ClassLoader parentClassloader = ClasspathUsingMavenFactory.class.getClassLoader();
+            return new URLClassLoader("legend-lsp", urls, parentClassloader);
+        }
+        catch (IOException | MavenInvocationException e)
+        {
+            throw new RuntimeException(e);
+        }
+        finally
+        {
+            this.outputStream.reset();
+        }
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/EmbeddedClasspathFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/EmbeddedClasspathFactory.java
@@ -1,0 +1,26 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.classpath;
+
+import org.eclipse.lsp4j.WorkspaceFolder;
+
+public class EmbeddedClasspathFactory implements ClasspathFactory
+{
+    @Override
+    public ClassLoader create(Iterable<? extends WorkspaceFolder> folders)
+    {
+        return EmbeddedClasspathFactory.class.getClassLoader();
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/ExtensionsGuard.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/ExtensionsGuard.java
@@ -1,0 +1,144 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.server;
+
+import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarLibrary;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPInlineDSLExtension;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPInlineDSLLibrary;
+
+class ExtensionsGuard
+{
+    private final Executor executor;
+    private final boolean async;
+    private final Iterable<LegendLSPGrammarExtension> providedGrammarExtensions;
+    private final Iterable<LegendLSPInlineDSLExtension> providedInlineDSLs;
+    private ClassLoader classLoader;
+    private LegendLSPGrammarLibrary grammars;
+    private LegendLSPInlineDSLLibrary inlineDSLs;
+
+    public ExtensionsGuard(boolean async, Executor executor, LegendLSPGrammarLibrary providedGrammarExtensions, LegendLSPInlineDSLLibrary providedInlineDSLs)
+    {
+        this.async = async;
+        this.executor = executor;
+        this.providedGrammarExtensions = providedGrammarExtensions.getExtensions();
+        this.providedInlineDSLs = providedInlineDSLs.getExtensions();
+    }
+
+    public void init(ClassLoader classLoader)
+    {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try
+        {
+            if (this.classLoader != null && this.classLoader instanceof Closeable)
+            {
+                ((Closeable) this.classLoader).close();
+            }
+
+            this.classLoader = classLoader;
+
+            Thread.currentThread().setContextClassLoader(classLoader);
+
+            this.grammars = LegendLSPGrammarLibrary.builder().withExtensions(this.providedGrammarExtensions).withExtensionsFrom(classLoader).build();
+            this.inlineDSLs = LegendLSPInlineDSLLibrary.builder().withExtensions(this.providedInlineDSLs).withExtensionsFrom(classLoader).build();
+        }
+        catch (Throwable e)
+        {
+            throw new RuntimeException(e);
+        }
+        finally
+        {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    public LegendLSPGrammarLibrary getGrammars()
+    {
+        return this.grammars;
+    }
+
+    public LegendLSPInlineDSLLibrary getInlineDSLs()
+    {
+        return this.inlineDSLs;
+    }
+
+    <T> CompletableFuture<T> supplyPossiblyAsync_internal(Supplier<T> work)
+    {
+        Supplier<T> supplier = this.wrapOnClasspath(work);
+
+        if (this.async)
+        {
+            return (this.executor == null) ?
+                    CompletableFuture.supplyAsync(supplier) :
+                    CompletableFuture.supplyAsync(supplier, this.executor);
+        }
+
+        return CompletableFuture.completedFuture(supplier.get());
+    }
+
+    CompletableFuture<?> runPossiblyAsync_internal(Runnable work)
+    {
+        Runnable runnable = this.wrapOnClasspath(work);
+
+        if (this.async)
+        {
+            return (this.executor == null) ?
+                    CompletableFuture.runAsync(runnable) :
+                    CompletableFuture.runAsync(runnable, this.executor);
+        }
+
+        runnable.run();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private Runnable wrapOnClasspath(Runnable command)
+    {
+        return () ->
+        {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            try
+            {
+                Thread.currentThread().setContextClassLoader(this.classLoader);
+                command.run();
+            }
+            finally
+            {
+                Thread.currentThread().setContextClassLoader(contextClassLoader);
+            }
+        };
+    }
+
+    private <T> Supplier<T> wrapOnClasspath(Supplier<T> command)
+    {
+        return () ->
+        {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            try
+            {
+                Thread.currentThread().setContextClassLoader(this.classLoader);
+                return command.get();
+            }
+            finally
+            {
+                Thread.currentThread().setContextClassLoader(contextClassLoader);
+            }
+        };
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
@@ -172,6 +172,8 @@ class LegendWorkspaceService implements WorkspaceService
     @Override
     public void didChangeWatchedFiles(DidChangeWatchedFilesParams params)
     {
+        // todo - retrigger classpath / classloader init?
+
         LOGGER.debug("Did change watched files: {}", params);
         this.server.runPossiblyAsync(() ->
         {
@@ -211,6 +213,8 @@ class LegendWorkspaceService implements WorkspaceService
     @Override
     public void didChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams params)
     {
+        // todo - retrigger classpath / classloader init?
+
         LOGGER.debug("Did change workspace folders: {}", params);
         synchronized (this.server.getGlobalState())
         {
@@ -222,6 +226,8 @@ class LegendWorkspaceService implements WorkspaceService
     @Override
     public void didCreateFiles(CreateFilesParams params)
     {
+        // todo - retrigger classpath / classloader init?
+
         LOGGER.debug("Did create files: {}", params);
         this.server.runPossiblyAsync(() ->
         {

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/maven/TestClasspathUsingMavenFactory.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/maven/TestClasspathUsingMavenFactory.java
@@ -1,0 +1,26 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.maven;
+
+import org.junit.jupiter.api.Test;
+
+class TestClasspathUsingMavenFactory
+{
+    @Test
+    void name()
+    {
+        //todo
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,9 @@
         <pac4j.version>3.8.3</pac4j.version>
         <slf4j.version>2.0.9</slf4j.version>
 
+        <maven.invoker.version>3.2.0</maven.invoker.version>
+        <maven.shared.utils.version>3.4.2</maven.shared.utils.version>
+
         <!-- Plugin versions -->
         <jacoco.maven.plugin.version>0.8.10</jacoco.maven.plugin.version>
         <maven.checkstyle.plugin.version>3.3.0</maven.checkstyle.plugin.version>
@@ -561,17 +564,6 @@
             </dependency>
             <dependency>
                 <groupId>org.finos.legend.engine</groupId>
-                <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-api</artifactId>
-                <version>${legend.engine.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.finos.legend.engine</groupId>
                 <artifactId>legend-engine-executionPlan-generation</artifactId>
                 <version>${legend.engine.version}</version>
                 <exclusions>
@@ -678,6 +670,19 @@
                 </exclusions>
             </dependency>
             <!-- LEGEND ENGINE -->
+
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-invoker</artifactId>
+                <version>${maven.invoker.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-shared-utils</artifactId>
+                <version>${maven.shared.utils.version}</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This reduces the shaded jar size by expecting the discovered extension dependencies to be download thru maven.

This is complemented on the client side by this:
 
https://github.com/finos/legend-engine-ide-client-vscode/pull/28