### PR TITLE
Reduce shaded jar size by managing runtime dependencies using maven

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/pom.xml
+++ b/legend-engine-ide-lsp-default-extensions/pom.xml
@@ -597,10 +597,6 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-relationalStore-executionPlan-connection-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-generation</artifactId>
         </dependency>
         <dependency>

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestConnectionLSPGrammarExtension.java
@@ -27,7 +27,6 @@ import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
-import org.finos.legend.engine.plan.execution.stores.relational.connection.api.schema.model.DatabaseBuilderInput;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.junit.jupiter.api.Assertions;
@@ -94,7 +93,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
                 ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
                 try
                 {
-                    DatabaseBuilderInput body = objectMapper.readValue(exchange.getRequestBody(), DatabaseBuilderInput.class);
+                    ConnectionLSPGrammarExtension.DatabaseBuilderInput body = objectMapper.readValue(exchange.getRequestBody(), ConnectionLSPGrammarExtension.DatabaseBuilderInput.class);
                     Assertions.assertEquals("model::MyStore", body.connection.element);
                     Assertions.assertEquals("model", body.targetDatabase._package);
                     Assertions.assertEquals("MyConnectionDatabase", body.targetDatabase.name);

--- a/legend-engine-ide-lsp-server-shaded/pom.xml
+++ b/legend-engine-ide-lsp-server-shaded/pom.xml
@@ -40,10 +40,14 @@
                         <bannedDependencies>
                             <includes>
                                 <include>ch.qos.logback:*:${logback.version}:jar:runtime</include>
-                                <include>com.google.code.gson:gson:*:jar:runtime</include>
                                 <include>org.eclipse.lsp4j:*:*:jar:runtime</include>
                                 <include>org.finos.legend.engine.ide.lsp:*:${project.version}:jar:runtime</include>
                                 <include>org.slf4j:slf4j-api:${slf4j.version}:jar:runtime</include>
+                                <!-- the below allowed dependencies are relocated on shaded jar to prevent conflicts when loading dynamically other jars-->
+                                <include>com.google.code.gson:gson:*:jar:runtime</include>
+                                <include>org.apache.maven.shared:maven-invoker:${maven.invoker.version}:jar:runtime</include>
+                                <include>org.apache.maven.shared:maven-shared-utils:${maven.shared.utils.version}:jar:runtime</include>
+                                <include>commons-io:commons-io:${commons-io.version}:jar:runtime</include>
                             </includes>
                         </bannedDependencies>
                     </rules>
@@ -78,6 +82,20 @@
                                     <mainClass>org.finos.legend.engine.ide.lsp.server.LegendLanguageServer</mainClass>
                                 </transformer>
                             </transformers>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.maven.shared</pattern>
+                                    <shadedPattern>org.finos.legend.engine.ide.lsp.shaded.org.apache.maven.shared</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.io</pattern>
+                                    <shadedPattern>org.finos.legend.engine.ide.lsp.shaded.org.apache.commons.io</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>org.finos.legend.engine.ide.lsp.shaded.com.google.gson</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/legend-engine-ide-lsp-server/pom.xml
+++ b/legend-engine-ide-lsp-server/pom.xml
@@ -44,6 +44,9 @@
                                 <include>org.eclipse.lsp4j:*:${lsp4j.version}:jar:compile</include>
                                 <include>org.finos.legend.engine.ide.lsp:*:${project.version}:jar:compile</include>
                                 <include>org.slf4j:slf4j-api:${slf4j.version}:jar:compile</include>
+                                <include>org.apache.maven.shared:maven-invoker:${maven.invoker.version}:jar:compile</include>
+                                <include>org.apache.maven.shared:maven-shared-utils:${maven.shared.utils.version}:jar:compile</include>
+                                <include>commons-io:commons-io:${commons-io.version}:jar:compile</include>
                             </includes>
                         </bannedDependencies>
                     </rules>
@@ -64,6 +67,16 @@
         </dependency>
         <!-- LEGEND ENGINE LSP -->
 
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-invoker</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+        </dependency>
+        
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathFactory.java
@@ -1,0 +1,23 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.classpath;
+
+import java.util.concurrent.CompletableFuture;
+import org.finos.legend.engine.ide.lsp.server.LegendLanguageServer;
+
+public interface ClasspathFactory
+{
+    CompletableFuture<ClassLoader> create(LegendLanguageServer server, Iterable<String> folders);
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
@@ -1,0 +1,187 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.classpath;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.InvokerLogger;
+import org.apache.maven.shared.invoker.PrintStreamHandler;
+import org.apache.maven.shared.invoker.PrintStreamLogger;
+import org.apache.maven.shared.utils.Os;
+import org.apache.maven.shared.utils.cli.CommandLineUtils;
+import org.apache.maven.shared.utils.cli.Commandline;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.finos.legend.engine.ide.lsp.server.LegendLanguageServer;
+
+public class ClasspathUsingMavenFactory implements ClasspathFactory
+{
+    private final Invoker invoker;
+    private final File defaultPom;
+    private final ByteArrayOutputStream outputStream;
+
+    public ClasspathUsingMavenFactory(File defaultPom)
+    {
+        this.defaultPom = defaultPom;
+        this.invoker = new DefaultInvoker();
+        this.outputStream = new ByteArrayOutputStream();
+        this.invoker.setLogger(new PrintStreamLogger(new PrintStream(this.outputStream, true), InvokerLogger.INFO));
+    }
+
+    private static File getMavenExecLocation(String mavenHome) throws Exception
+    {
+        if (mavenHome == null || mavenHome.isEmpty())
+        {
+            Commandline commandline = new Commandline();
+
+            if (Os.isFamily(Os.FAMILY_WINDOWS))
+            {
+                commandline.setExecutable("where");
+                commandline.addArguments("mvn");
+            }
+            else if (Os.isFamily(Os.FAMILY_UNIX))
+            {
+                commandline.setExecutable("which");
+                commandline.addArguments("mvn");
+            }
+            else
+            {
+                throw new UnsupportedOperationException("OS not supported");
+            }
+
+            CommandLineUtils.StringStreamConsumer systemOut = new CommandLineUtils.StringStreamConsumer();
+            CommandLineUtils.StringStreamConsumer systemErr = new CommandLineUtils.StringStreamConsumer();
+            int result = CommandLineUtils.executeCommandLine(commandline, systemOut, systemErr, 2);
+
+            if (result == 0)
+            {
+                String[] split = systemOut.getOutput().split(System.lineSeparator());
+                if (split.length == 0)
+                {
+                    return null;
+                }
+                String location = split[0];
+                return new File(location);
+            }
+            else
+            {
+                throw new RuntimeException("Error finding mvn executable: " + systemErr.getOutput());
+            }
+        }
+        else
+        {
+            return new File(mavenHome);
+        }
+    }
+
+    @Override
+    public CompletableFuture<ClassLoader> create(LegendLanguageServer server, Iterable<String> folders)
+    {
+        server.logInfoToClient("Discovering classpath using maven");
+
+        ConfigurationItem mavenExecPathConfig = new ConfigurationItem();
+        mavenExecPathConfig.setSection("maven.executable.path");
+
+        ConfigurationItem defaultPomConfig = new ConfigurationItem();
+        defaultPomConfig.setSection("legend.extensions.dependencies.pom");
+
+        ConfigurationParams configurationParams = new ConfigurationParams(Arrays.asList(mavenExecPathConfig, defaultPomConfig));
+        return server.getLanguageClient().configuration(configurationParams).thenApply(x ->
+        {
+            String mavenExecPath = server.extractValueAs(x.get(0), String.class);
+            String overrideDefaultPom = server.extractValueAs(x.get(1), String.class);
+
+            try
+            {
+                File maven = getMavenExecLocation(mavenExecPath);
+                server.logInfoToClient("Maven path: " + maven);
+
+                File pom = (overrideDefaultPom == null || overrideDefaultPom.isEmpty()) ? this.defaultPom : new File(overrideDefaultPom);
+
+                // todo apply properties from /project.json is this exists...
+                // todo if project.json exists, use pom from a sub-module
+                // todo otherwise, check if pom exists on root
+                // todo last, use a default pom...
+
+                server.logInfoToClient("Dependencies loaded from POM: " + pom);
+
+                File legendLspClasspath = File.createTempFile("legend_lsp_classpath", ".txt");
+                legendLspClasspath.deleteOnExit();
+
+                Properties properties = new Properties();
+                properties.setProperty("mdep.outputFile", legendLspClasspath.getAbsolutePath());
+
+                InvocationRequest request = new DefaultInvocationRequest();
+                request.setPomFile(pom);
+                request.setOutputHandler(new PrintStreamHandler(new PrintStream(this.outputStream, true), true));
+                request.setGoals(Collections.singletonList("dependency:build-classpath"));
+                request.setProperties(properties);
+                request.setTimeoutInSeconds((int) TimeUnit.MINUTES.toSeconds(5));
+                request.setJavaHome(Optional.ofNullable(System.getProperty("java.home")).map(File::new).orElse(null));
+                request.setMavenHome(maven);
+
+                InvocationResult result = this.invoker.execute(request);
+                if (result.getExitCode() != 0)
+                {
+                    String output = this.outputStream.toString(StandardCharsets.UTF_8);
+                    throw new IllegalStateException("Maven invoker failed\n\n" + output, result.getExecutionException());
+                }
+
+                String classpath = Files.readString(legendLspClasspath.toPath(), StandardCharsets.UTF_8);
+
+                server.logInfoToClient("Classpath used: " + classpath);
+
+                String[] classpathEntries = classpath.split(";");
+                URL[] urls = new URL[classpathEntries.length];
+
+                for (int i = 0; i < urls.length; i++)
+                {
+                    urls[i] = new File(classpathEntries[i]).toURI().toURL();
+                }
+
+                ClassLoader parentClassloader = ClasspathUsingMavenFactory.class.getClassLoader();
+                return new URLClassLoader("legend-lsp", urls, parentClassloader);
+            }
+            catch (RuntimeException e)
+            {
+                throw e;
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+            finally
+            {
+                this.outputStream.reset();
+            }
+        });
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/EmbeddedClasspathFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/EmbeddedClasspathFactory.java
@@ -1,0 +1,28 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.classpath;
+
+import java.util.concurrent.CompletableFuture;
+import org.finos.legend.engine.ide.lsp.server.LegendLanguageServer;
+
+public class EmbeddedClasspathFactory implements ClasspathFactory
+{
+    @Override
+    public CompletableFuture<ClassLoader> create(LegendLanguageServer server, Iterable<String> folders)
+    {
+        server.logInfoToClient("Using app classpath");
+        return CompletableFuture.completedFuture(EmbeddedClasspathFactory.class.getClassLoader());
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/ExtensionsGuard.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/ExtensionsGuard.java
@@ -15,6 +15,8 @@
 package org.finos.legend.engine.ide.lsp.server;
 
 import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.function.Supplier;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarLibrary;
@@ -62,9 +64,9 @@ class ExtensionsGuard
 
             this.classLoader = classLoader;
         }
-        catch (Throwable e)
+        catch (IOException e)
         {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
         finally
         {

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/ExtensionsGuard.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/ExtensionsGuard.java
@@ -1,0 +1,118 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.server;
+
+import java.io.Closeable;
+import java.util.function.Supplier;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarLibrary;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPInlineDSLExtension;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPInlineDSLLibrary;
+
+class ExtensionsGuard
+{
+    private final Iterable<LegendLSPGrammarExtension> providedGrammarExtensions;
+    private final Iterable<LegendLSPInlineDSLExtension> providedInlineDSLs;
+    private final LegendLanguageServer server;
+    private volatile ClassLoader classLoader;
+    private volatile LegendLSPGrammarLibrary grammars;
+    private volatile LegendLSPInlineDSLLibrary inlineDSLs;
+
+    public ExtensionsGuard(LegendLanguageServer server, LegendLSPGrammarLibrary providedGrammarExtensions, LegendLSPInlineDSLLibrary providedInlineDSLs)
+    {
+        this.server = server;
+        this.grammars = providedGrammarExtensions;
+        this.inlineDSLs = providedInlineDSLs;
+        this.providedGrammarExtensions = providedGrammarExtensions.getExtensions();
+        this.providedInlineDSLs = providedInlineDSLs.getExtensions();
+    }
+
+    public synchronized void initialize(ClassLoader classLoader)
+    {
+        this.server.logInfoToClient("Initializing grammar extensions");
+
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        try
+        {
+            if (this.classLoader != null && this.classLoader instanceof Closeable)
+            {
+                ((Closeable) this.classLoader).close();
+            }
+
+            Thread.currentThread().setContextClassLoader(classLoader);
+
+            this.grammars = LegendLSPGrammarLibrary.builder().withExtensions(this.providedGrammarExtensions).withExtensionsFrom(classLoader).build();
+            this.inlineDSLs = LegendLSPInlineDSLLibrary.builder().withExtensions(this.providedInlineDSLs).withExtensionsFrom(classLoader).build();
+
+            this.server.logInfoToClient("Grammar extensions available: " + String.join(", ", this.grammars.getExtensionNames()));
+            this.server.logInfoToClient("Inline DSL extensions available: " + String.join(", ", this.inlineDSLs.getExtensionNames()));
+
+            this.classLoader = classLoader;
+        }
+        catch (Throwable e)
+        {
+            throw new RuntimeException(e);
+        }
+        finally
+        {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    public LegendLSPGrammarLibrary getGrammars()
+    {
+        return this.grammars;
+    }
+
+    public LegendLSPInlineDSLLibrary getInlineDSLs()
+    {
+        return this.inlineDSLs;
+    }
+
+    Runnable wrapOnClasspath(Runnable command)
+    {
+        return () ->
+        {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            try
+            {
+                Thread.currentThread().setContextClassLoader(this.classLoader);
+                command.run();
+            }
+            finally
+            {
+                Thread.currentThread().setContextClassLoader(contextClassLoader);
+            }
+        };
+    }
+
+    <T> Supplier<T> wrapOnClasspath(Supplier<T> command)
+    {
+        return () ->
+        {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            try
+            {
+                Thread.currentThread().setContextClassLoader(this.classLoader);
+                return command.get();
+            }
+            finally
+            {
+                Thread.currentThread().setContextClassLoader(contextClassLoader);
+            }
+        };
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
@@ -17,7 +17,25 @@ package org.finos.legend.engine.ide.lsp.server;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.eclipse.lsp4j.CodeLensOptions;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.FileOperationFilter;
 import org.eclipse.lsp4j.FileOperationOptions;
@@ -53,6 +71,9 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import org.finos.legend.engine.ide.lsp.classpath.ClasspathFactory;
+import org.finos.legend.engine.ide.lsp.classpath.ClasspathUsingMavenFactory;
+import org.finos.legend.engine.ide.lsp.classpath.EmbeddedClasspathFactory;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarLibrary;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPInlineDSLExtension;
@@ -60,21 +81,6 @@ import org.finos.legend.engine.ide.lsp.extension.LegendLSPInlineDSLLibrary;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.ServiceLoader;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * {@link LanguageServer} implementation for Legend.
@@ -95,44 +101,148 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
     private final LegendWorkspaceService workspaceService;
     private final AtomicReference<LanguageClient> languageClient = new AtomicReference<>(null);
     private final AtomicInteger state = new AtomicInteger(UNINITIALIZED);
-    private final boolean async;
+    private final ClasspathFactory classpathFactory;
+    private final ExtensionsGuard extensionGuard;
     private final Executor executor;
-    private final LegendLSPGrammarLibrary grammars;
-    private final LegendLSPInlineDSLLibrary inlineDSLs;
+    private final boolean async;
     private final LegendServerGlobalState globalState = new LegendServerGlobalState(this);
     private final AtomicInteger progressId = new AtomicInteger();
     private final Gson gson = new Gson();
-
     private final Set<String> rootFolders = new HashSet<>();
 
-    private LegendLanguageServer(boolean async, Executor executor, LegendLSPGrammarLibrary grammars, LegendLSPInlineDSLLibrary inlineDSLs)
+    private LegendLanguageServer(boolean async, Executor executor, ClasspathFactory classpathFactory, LegendLSPGrammarLibrary grammars, LegendLSPInlineDSLLibrary inlineDSLs)
     {
         this.textDocumentService = new LegendTextDocumentService(this);
         this.workspaceService = new LegendWorkspaceService(this);
+        this.extensionGuard = new ExtensionsGuard(this, grammars, inlineDSLs);
         this.async = async;
         this.executor = executor;
-        this.grammars = grammars;
-        this.inlineDSLs = inlineDSLs;
+        this.classpathFactory = Objects.requireNonNull(classpathFactory, "missing classpath factory");
     }
 
     @Override
     public CompletableFuture<InitializeResult> initialize(InitializeParams initializeParams)
     {
         LOGGER.debug("Initialize server requested: {}", initializeParams);
-        int currentState = this.state.get();
-        if (currentState >= INITIALIZING)
+        if (this.state.get() >= INITIALIZING)
         {
-            String message = getCannotInitializeMessage(currentState);
+            String message = getCannotInitializeMessage(this.state.get());
             LOGGER.error(message);
             throw newResponseErrorException(ResponseErrorCode.RequestFailed, message);
         }
-        return supplyPossiblyAsync_internal(() -> doInitialize(initializeParams));
+
+        LOGGER.info("Initializing server");
+        LOGGER.debug("Initialize params: {}", initializeParams);
+        if (!this.state.compareAndSet(UNINITIALIZED, INITIALIZING))
+        {
+            String message = getCannotInitializeMessage(this.state.get());
+            LOGGER.warn(message);
+            logWarningToClient(message);
+            throw newResponseErrorException(ResponseErrorCode.RequestFailed, message);
+        }
+
+        logInfoToClient("Initializing server");
+        List<WorkspaceFolder> workspaceFolders = initializeParams.getWorkspaceFolders();
+
+        InitializeResult result = new InitializeResult(getServerCapabilities());
+        CompletableFuture<InitializeResult> completableFuture = CompletableFuture.completedFuture(result);
+        CompletableFuture<InitializeResult> initFuture = completableFuture;
+
+        if (workspaceFolders != null)
+        {
+            initFuture = setWorkspaceFolders(workspaceFolders).thenComposeAsync(x -> completableFuture);
+        }
+
+        if (!this.state.compareAndSet(INITIALIZING, INITIALIZED))
+        {
+            String message;
+            switch (this.state.get())
+            {
+                case SHUTTING_DOWN:
+                {
+                    message = "Server began shutting down during initialization";
+                    break;
+                }
+                case SHUT_DOWN:
+                {
+                    message = "Server shut down during initialization";
+                    break;
+                }
+                default:
+                {
+                    message = "Server entered unexpected state during initialization: " + getStateDescription(this.state.get());
+                }
+            }
+            LOGGER.warn(message);
+            logWarningToClient(message);
+            throw newResponseErrorException(ResponseErrorCode.RequestFailed, message);
+        }
+        LOGGER.info("Server initialized");
+        logInfoToClient("Server initialized");
+        return initFuture;
     }
 
     @Override
     public void initialized(InitializedParams params)
     {
         checkReady();
+        this.initializeExtensions();
+        this.initializeEngineServerUrl();
+    }
+
+    private void initializeEngineServerUrl()
+    {
+        ConfigurationItem urlConfig = new ConfigurationItem();
+        urlConfig.setSection("legend.engine.server.url");
+
+        ConfigurationParams configurationParams = new ConfigurationParams(Arrays.asList(urlConfig));
+        this.getLanguageClient().configuration(configurationParams).thenAccept(x ->
+        {
+            String url = this.extractValueAs(x.get(0), String.class);
+            this.setEngineServerUrl(url);
+        });
+    }
+
+    private void setEngineServerUrl(String url)
+    {
+        if (url != null && !url.isEmpty())
+        {
+            this.logInfoToClient("Using server URL: " + url);
+            System.setProperty("legend.engine.server.url", url);
+        }
+        else
+        {
+            this.logWarningToClient("No server URL found.  Some functionality won't work");
+            System.clearProperty("legend.engine.server.url");
+        }
+    }
+
+    private void initializeExtensions()
+    {
+        logInfoToClient("Initializing extensions");
+
+        this.classpathFactory.create(this, Collections.unmodifiableSet(this.rootFolders))
+                .thenAccept(this.extensionGuard::initialize)
+                .thenRun(this.extensionGuard.wrapOnClasspath(this::reprocessDocuments))
+                .thenRun(() ->
+                {
+                    LanguageClient languageClient = this.getLanguageClient();
+                    languageClient.refreshCodeLenses();
+                    languageClient.refreshDiagnostics();
+                    languageClient.refreshInlayHints();
+                    languageClient.refreshInlineValues();
+                    languageClient.refreshSemanticTokens();
+                }).exceptionally(x ->
+                {
+                    LOGGER.error("Failed during post-initialization", x);
+                    logErrorToClient("Failed during post-initialization: " + x.getMessage());
+                    return null;
+                });
+    }
+
+    private void reprocessDocuments()
+    {
+        this.globalState.forEachDocumentState(x -> ((LegendServerGlobalState.LegendServerDocumentState) x).recreateSectionStates());
     }
 
     @Override
@@ -145,7 +255,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
             LOGGER.warn("Server already {}", getStateDescription(currentState));
             return CompletableFuture.completedFuture(null);
         }
-        return supplyPossiblyAsync_internal(() ->
+        return this.supplyPossiblyAsync_internal(() ->
         {
             doShutdown();
             return null;
@@ -290,13 +400,35 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
     <T> CompletableFuture<T> supplyPossiblyAsync(Supplier<T> supplier)
     {
         checkReady();
-        return supplyPossiblyAsync_internal(supplier);
+        return this.supplyPossiblyAsync_internal(this.extensionGuard.wrapOnClasspath(supplier));
     }
 
     CompletableFuture<?> runPossiblyAsync(Runnable runnable)
     {
         checkReady();
-        return runPossiblyAsync_internal(runnable);
+        return this.runPossiblyAsync_internal(this.extensionGuard.wrapOnClasspath(runnable));
+    }
+
+    private CompletableFuture<?> runPossiblyAsync_internal(Runnable work)
+    {
+        return this.supplyPossiblyAsync_internal(() ->
+                {
+                    work.run();
+                    return null;
+                }
+        );
+    }
+
+    private <T> CompletableFuture<T> supplyPossiblyAsync_internal(Supplier<T> work)
+    {
+        if (this.async)
+        {
+            return (this.executor == null) ?
+                    CompletableFuture.supplyAsync(work) :
+                    CompletableFuture.supplyAsync(work, this.executor);
+        }
+
+        return CompletableFuture.completedFuture(work.get());
     }
 
     LegendServerGlobalState getGlobalState()
@@ -305,7 +437,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
         return this.globalState;
     }
 
-    LanguageClient getLanguageClient()
+    public LanguageClient getLanguageClient()
     {
         checkNotShutDown();
         return this.languageClient.get();
@@ -314,22 +446,22 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
     LegendLSPGrammarLibrary getGrammarLibrary()
     {
         checkNotShutDown();
-        return this.grammars;
+        return this.extensionGuard.getGrammars();
     }
 
     LegendLSPGrammarExtension getGrammarExtension(String grammar)
     {
         checkNotShutDown();
-        return this.grammars.getExtension(grammar);
+        return this.extensionGuard.getGrammars().getExtension(grammar);
     }
 
     LegendLSPInlineDSLLibrary getInlineDSLLibrary()
     {
         checkNotShutDown();
-        return this.inlineDSLs;
+        return this.extensionGuard.getInlineDSLs();
     }
 
-    void setWorkspaceFolders(Iterable<? extends WorkspaceFolder> folders)
+    CompletableFuture<?> setWorkspaceFolders(Iterable<? extends WorkspaceFolder> folders)
     {
         List<String> addedFolders;
         List<String> removedFolders;
@@ -346,7 +478,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
             this.rootFolders.addAll(newRootFolders);
         }
 
-        updateStateWithFolderChanges(addedFolders, removedFolders);
+        return updateStateWithFolderChanges(addedFolders, removedFolders);
     }
 
     void addRootFolderFromFile(String fileUri)
@@ -373,7 +505,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
             String message = "Added root folder: " + folderUri;
             LOGGER.info(message);
             logInfoToClient(message);
-            runPossiblyAsync_internal(() -> this.globalState.addFolder(folderUri));
+            this.runPossiblyAsync_internal(() -> this.globalState.addFolder(folderUri));
         }
     }
 
@@ -410,7 +542,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
         }
     }
 
-    private void updateStateWithFolderChanges(List<String> addedFolders, List<String> removedFolders)
+    private CompletableFuture<?> updateStateWithFolderChanges(Collection<String> addedFolders, Collection<String> removedFolders)
     {
         if ((addedFolders != null) && !addedFolders.isEmpty())
         {
@@ -424,17 +556,17 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
             LOGGER.info(message);
             logInfoToClient(message);
         }
-        runPossiblyAsync_internal(() ->
+        return this.runPossiblyAsync_internal(this.extensionGuard.wrapOnClasspath(() ->
         {
-           if (addedFolders != null)
-           {
-               addedFolders.forEach(this.globalState::addFolder);
-           }
-           if (removedFolders != null)
-           {
-               removedFolders.forEach(this.globalState::removeFolder);
-           }
-        });
+            if (addedFolders != null)
+            {
+                addedFolders.forEach(this.globalState::addFolder);
+            }
+            if (removedFolders != null)
+            {
+                removedFolders.forEach(this.globalState::removeFolder);
+            }
+        }));
     }
 
     void logToClient(String message)
@@ -442,7 +574,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
         logToClient(MessageType.Log, message);
     }
 
-    void logInfoToClient(String message)
+    public void logInfoToClient(String message)
     {
         logToClient(MessageType.Info, message);
     }
@@ -573,7 +705,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
     }
 
     @SuppressWarnings("unchecked")
-    <T> T extractValueAs(Object value, Class<T> cls)
+    public <T> T extractValueAs(Object value, Class<T> cls)
     {
         if (value == null)
         {
@@ -614,87 +746,6 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
             return this.gson.fromJson((String) value, (TypeToken<Map<K, V>>) TypeToken.getParameterized(Map.class, keyType, valueType));
         }
         return null;
-    }
-
-    private <T> CompletableFuture<T> supplyPossiblyAsync_internal(Supplier<T> supplier)
-    {
-        return this.async ?
-                supplyAsync(supplier) :
-                CompletableFuture.completedFuture(supplier.get());
-    }
-
-    private CompletableFuture<?> runPossiblyAsync_internal(Runnable runnable)
-    {
-        if (this.async)
-        {
-            return runAsync(runnable);
-        }
-
-        runnable.run();
-        return CompletableFuture.completedFuture(null);
-    }
-
-    private <T> CompletableFuture<T> supplyAsync(Supplier<T> supplier)
-    {
-        return (this.executor == null) ?
-                CompletableFuture.supplyAsync(supplier) :
-                CompletableFuture.supplyAsync(supplier, this.executor);
-    }
-
-    private CompletableFuture<?> runAsync(Runnable runnable)
-    {
-        return (this.executor == null) ?
-                CompletableFuture.runAsync(runnable) :
-                CompletableFuture.runAsync(runnable, this.executor);
-    }
-
-    private InitializeResult doInitialize(InitializeParams initializeParams)
-    {
-        LOGGER.info("Initializing server");
-        LOGGER.debug("Initialize params: {}", initializeParams);
-        if (!this.state.compareAndSet(UNINITIALIZED, INITIALIZING))
-        {
-            String message = getCannotInitializeMessage(this.state.get());
-            LOGGER.warn(message);
-            logWarningToClient(message);
-            throw newResponseErrorException(ResponseErrorCode.RequestFailed, message);
-        }
-
-        logInfoToClient("Initializing server");
-        List<WorkspaceFolder> workspaceFolders = initializeParams.getWorkspaceFolders();
-        if (workspaceFolders != null)
-        {
-            setWorkspaceFolders(workspaceFolders);
-        }
-        InitializeResult result = new InitializeResult(getServerCapabilities());
-        if (!this.state.compareAndSet(INITIALIZING, INITIALIZED))
-        {
-            int currentState = this.state.get();
-            String message;
-            switch (currentState)
-            {
-                case SHUTTING_DOWN:
-                {
-                    message = "Server began shutting down during initialization";
-                    break;
-                }
-                case SHUT_DOWN:
-                {
-                    message = "Server shut down during initialization";
-                    break;
-                }
-                default:
-                {
-                    message = "Server entered unexpected state during initialization: " + getStateDescription(currentState);
-                }
-            }
-            LOGGER.warn(message);
-            logWarningToClient(message);
-            throw newResponseErrorException(ResponseErrorCode.RequestFailed, message);
-        }
-        LOGGER.info("Server initialized");
-        logInfoToClient("Server initialized");
-        return result;
     }
 
     private String getCannotInitializeMessage(int currentState)
@@ -872,6 +923,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
     {
         private boolean async = true;
         private Executor executor;
+        private ClasspathFactory classpathFactory = new EmbeddedClasspathFactory();
         private final LegendLSPGrammarLibrary.Builder grammars = LegendLSPGrammarLibrary.builder();
         private final LegendLSPInlineDSLLibrary.Builder inlineDSLs = LegendLSPInlineDSLLibrary.builder();
 
@@ -888,6 +940,12 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
         {
             this.async = false;
             this.executor = null;
+            return this;
+        }
+
+        public Builder classpathFromMaven(File defaultPom)
+        {
+            this.classpathFactory = new ClasspathUsingMavenFactory(defaultPom);
             return this;
         }
 
@@ -1000,7 +1058,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
          */
         public LegendLanguageServer build()
         {
-            return new LegendLanguageServer(this.async, this.executor, this.grammars.build(), this.inlineDSLs.build());
+            return new LegendLanguageServer(this.async, this.executor, this.classpathFactory, this.grammars.build(), this.inlineDSLs.build());
         }
 
     }
@@ -1014,8 +1072,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
     {
         LOGGER.info("Launching server");
         LegendLanguageServer server = LegendLanguageServer.builder()
-                .withGrammars(ServiceLoader.load(LegendLSPGrammarExtension.class))
-                .withInlineDSLs(ServiceLoader.load(LegendLSPInlineDSLExtension.class))
+                .classpathFromMaven(new File(args[0]))
                 .build();
         Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, System.in, System.out);
         server.connect(launcher.getRemoteProxy());

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendServerGlobalState.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendServerGlobalState.java
@@ -397,6 +397,15 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
             this.sectionStates = createSectionStates(this.sectionIndex);
         }
 
+        public void recreateSectionStates()
+        {
+            synchronized (this.lock)
+            {
+                this.globalState.clearProperties();
+                this.sectionStates = createSectionStates(this.sectionIndex);
+            }
+        }
+
         private List<LegendServerSectionState> createSectionStates(GrammarSectionIndex index)
         {
             if (index == null)

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
@@ -167,11 +167,17 @@ class LegendWorkspaceService implements WorkspaceService
     {
         this.server.checkReady();
         LOGGER.debug("Did change configuration: {}", params);
+        // todo maybe server can have a map of configs to consumers of these properties
+        // todo if default pom changes? this.server.initializeExtensions();
+        // todo this.server.setEngineServerUrl();
     }
 
     @Override
     public void didChangeWatchedFiles(DidChangeWatchedFilesParams params)
     {
+        // todo - retrigger classpath / classloader init?
+        // todo this.server.initializeExtensions();
+
         LOGGER.debug("Did change watched files: {}", params);
         this.server.runPossiblyAsync(() ->
         {
@@ -211,6 +217,8 @@ class LegendWorkspaceService implements WorkspaceService
     @Override
     public void didChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams params)
     {
+        // todo - retrigger classpath / classloader init?
+
         LOGGER.debug("Did change workspace folders: {}", params);
         synchronized (this.server.getGlobalState())
         {
@@ -222,6 +230,8 @@ class LegendWorkspaceService implements WorkspaceService
     @Override
     public void didCreateFiles(CreateFilesParams params)
     {
+        // todo - retrigger classpath / classloader init?
+
         LOGGER.debug("Did create files: {}", params);
         this.server.runPossiblyAsync(() ->
         {

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/DummyLanguageClient.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/DummyLanguageClient.java
@@ -1,0 +1,104 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.eclipse.lsp4j.ConfigurationItem;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+public class DummyLanguageClient implements LanguageClient
+{
+    public final List<String> clientLog = new ArrayList<>();
+
+    @Override
+    public void telemetryEvent(Object object)
+    {
+        clientLog.add("telemetryEvent");
+    }
+
+    @Override
+    public void publishDiagnostics(PublishDiagnosticsParams diagnostics)
+    {
+        clientLog.add("publishDiagnostics");
+    }
+
+    @Override
+    public void showMessage(MessageParams messageParams)
+    {
+        clientLog.add("showMessage");
+    }
+
+    @Override
+    public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void logMessage(MessageParams message)
+    {
+        clientLog.add(String.format("logMessage - %s - %s", message.getType().name(), message.getMessage()));
+    }
+
+    @Override
+    public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams)
+    {
+        clientLog.add(String.format("configuration - %s", configurationParams.getItems().stream().map(ConfigurationItem::getSection).collect(Collectors.joining())));
+        return CompletableFuture.completedFuture(configurationParams.getItems().stream().map(x -> null).collect(Collectors.toList()));
+    }
+
+    @Override
+    public CompletableFuture<Void> refreshSemanticTokens()
+    {
+        clientLog.add("refreshSemanticTokens");
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> refreshCodeLenses()
+    {
+        clientLog.add("refreshCodeLenses");
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> refreshInlayHints()
+    {
+        clientLog.add("refreshInlayHints");
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> refreshInlineValues()
+    {
+        clientLog.add("refreshInlineValues");
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> refreshDiagnostics()
+    {
+        clientLog.add("refreshDiagnostics");
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/maven/TestClasspathUsingMavenFactory.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/maven/TestClasspathUsingMavenFactory.java
@@ -1,0 +1,63 @@
+// Copyright 2024 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.engine.ide.lsp.maven;
+
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import org.finos.legend.engine.ide.lsp.DummyLanguageClient;
+import org.finos.legend.engine.ide.lsp.classpath.ClasspathUsingMavenFactory;
+import org.finos.legend.engine.ide.lsp.server.LegendLanguageServer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestClasspathUsingMavenFactory
+{
+    @Test
+    void loadJarsFromPom(@TempDir Path tempDir) throws Exception
+    {
+        Path pom = tempDir.resolve("pom.xml");
+
+        Files.writeString(pom,
+                "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n" +
+                        "    <modelVersion>4.0.0</modelVersion>\n" +
+                        "\n" +
+                        "    <groupId>org.finos.legend.engine.ide.lsp</groupId>\n" +
+                        "    <artifactId>legend-engine-ide-lsp-server-sample-pom</artifactId>\n" +
+                        "    <version>0.0.0-SNAPSHOT</version>\n" +
+                        "\n" +
+                        "    <dependencies>\n" +
+                        "        <dependency>\n" +
+                        "            <groupId>commons-io</groupId>\n" +
+                        "            <artifactId>commons-io</artifactId>\n" +
+                        "            <version>2.15.1</version>\n" +
+                        "        </dependency>\n" +
+                        "    </dependencies>\n" +
+                        "</project>");
+
+        LegendLanguageServer server = LegendLanguageServer.builder().synchronous().build();
+        DummyLanguageClient languageClient = new DummyLanguageClient();
+        server.connect(languageClient);
+
+        ClassLoader classLoader = new ClasspathUsingMavenFactory(pom.toFile())
+                .create(server, Collections.emptyList()).get();
+
+        Assertions.assertInstanceOf(URLClassLoader.class, classLoader);
+        Assertions.assertEquals(1, ((URLClassLoader) classLoader).getURLs().length);
+        Assertions.assertTrue(((URLClassLoader) classLoader).getURLs()[0].toString().endsWith("commons-io-2.15.1.jar"));
+    }
+}

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/maven/TestClasspathUsingMavenFactory.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/maven/TestClasspathUsingMavenFactory.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.ide.lsp.maven;
 
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -47,7 +48,7 @@ class TestClasspathUsingMavenFactory
                         "            <version>2.15.1</version>\n" +
                         "        </dependency>\n" +
                         "    </dependencies>\n" +
-                        "</project>");
+                        "</project>", StandardCharsets.UTF_8);
 
         LegendLanguageServer server = LegendLanguageServer.builder().synchronous().build();
         DummyLanguageClient languageClient = new DummyLanguageClient();
@@ -56,8 +57,10 @@ class TestClasspathUsingMavenFactory
         ClassLoader classLoader = new ClasspathUsingMavenFactory(pom.toFile())
                 .create(server, Collections.emptyList()).get();
 
-        Assertions.assertInstanceOf(URLClassLoader.class, classLoader);
-        Assertions.assertEquals(1, ((URLClassLoader) classLoader).getURLs().length);
-        Assertions.assertTrue(((URLClassLoader) classLoader).getURLs()[0].toString().endsWith("commons-io-2.15.1.jar"));
+        try (URLClassLoader urlClassLoader = Assertions.assertInstanceOf(URLClassLoader.class, classLoader))
+        {
+            Assertions.assertEquals(1, urlClassLoader.getURLs().length);
+            Assertions.assertTrue(urlClassLoader.getURLs()[0].toString().endsWith("commons-io-2.15.1.jar"));
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,10 @@
         <junit.version>5.10.1</junit.version>
         <slf4j.version>2.0.10</slf4j.version>
 
+        <commons-io.version>2.15.1</commons-io.version>
+        <maven.invoker.version>3.2.0</maven.invoker.version>
+        <maven.shared.utils.version>3.4.2</maven.shared.utils.version>
+
         <!-- Plugin versions -->
         <jacoco.maven.plugin.version>0.8.10</jacoco.maven.plugin.version>
         <maven.checkstyle.plugin.version>3.3.0</maven.checkstyle.plugin.version>
@@ -135,6 +139,9 @@
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
                         <reportsDirectory>${project.parent.basedir}/legend-engine-ide-lsp-test-reports/surefire-reports-aggregate</reportsDirectory>
+                        <systemPropertyVariables>
+                            <maven.home>${maven.home}</maven.home>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -325,6 +332,30 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <!-- LOGGING -->
+
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-invoker</artifactId>
+                <version>${maven.invoker.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-shared-utils</artifactId>
+                <version>${maven.shared.utils.version}</version>
+            </dependency>
 
             <!-- TEST -->
             <dependency>


### PR DESCRIPTION
This reduces the shaded jar size by expecting the discovered extension dependencies to be download thru maven.

This is complemented on the client side by this:
 
https://github.com/finos/legend-engine-ide-client-vscode/pull/28