### PR TITLE
Improve completions to suggest available grammars and elements within those grammars

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/pom.xml
+++ b/legend-engine-ide-lsp-default-extensions/pom.xml
@@ -51,6 +51,11 @@
                 <scope>import</scope>
                 <version>${legend.engine.version}</version>
             </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -25,8 +25,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -34,6 +37,7 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.block.function.checked.ThrowingFunction;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendCommand;
@@ -44,6 +48,7 @@ import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.GrammarSection;
 import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.language.pure.compiler.Compiler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.Warning;
@@ -388,7 +393,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
         return sectionState.getProperty(PARSE_RESULT, () -> tryParse(sectionState));
     }
 
-    protected ParseResult tryParse(SectionState sectionState)
+    private ParseResult tryParse(SectionState sectionState)
     {
         MutableList<PackageableElement> elements = Lists.mutable.empty();
         try
@@ -627,6 +632,21 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
         }
     }
 
+    protected Optional<PackageableElement> getElementAtPosition(SectionState sectionState, TextPosition position)
+    {
+        ParseResult parseResult = this.getParseResult(sectionState);
+        return parseResult
+                .getElements()
+                .stream()
+                .filter(x -> this.isPositionIncludedOnSourceInfo(position, x.sourceInformation))
+                .findAny();
+    }
+
+    private boolean isPositionIncludedOnSourceInfo(TextPosition position, SourceInformation sourceInformation)
+    {
+        return isValidSourceInfo(sourceInformation) && toLocation(sourceInformation).includes(position);
+    }
+
     /**
      * Check if the source information is valid.
      *
@@ -651,6 +671,22 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
     protected static TextInterval toLocation(SourceInformation sourceInfo)
     {
         return TextInterval.newInterval(sourceInfo.startLine - 1, sourceInfo.startColumn - 1, sourceInfo.endLine - 1, sourceInfo.endColumn - 1);
+    }
+
+    protected Iterable<LegendCompletion> computeCompletionsForSupportedTypes(SectionState section, TextPosition location, Set<String> supportedTypes)
+    {
+        String text = section.getSection().getPrecedingText(location);
+
+        if (text.isEmpty())
+        {
+            return supportedTypes.stream().map(x -> new LegendCompletion("New " + x, x)).collect(Collectors.toList());
+        }
+        else if (this.getElementAtPosition(section, location).isEmpty())
+        {
+            return supportedTypes.stream().filter(x -> x.startsWith(text)).map(x -> new LegendCompletion("New " + x, x)).collect(Collectors.toList());
+        }
+
+        return List.of();
     }
 
     private static LegendEngineServerClient newEngineServerClient()

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -675,7 +675,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
 
     protected Iterable<LegendCompletion> computeCompletionsForSupportedTypes(SectionState section, TextPosition location, Set<String> supportedTypes)
     {
-        String text = section.getSection().getPrecedingText(location);
+        String text = section.getSection().getLineUpTo(location);
 
         if (text.isEmpty())
         {

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ConnectionLSPGrammarExtension.java
@@ -22,9 +22,11 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.set.MutableSet;
+import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult.Type;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.language.pure.grammar.from.connection.ConnectionParser;
 import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensionLoader;
 import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
@@ -75,6 +77,12 @@ public class ConnectionLSPGrammarExtension extends AbstractLegacyParserLSPGramma
         return GENERATE_DB_COMMAND_ID.equals(commandId) ?
                 generateDBFromConnection(section, entityPath) :
                 super.execute(section, entityPath, commandId, executableArgs);
+    }
+
+    @Override
+    public Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
+    {
+        return this.computeCompletionsForSupportedTypes(section, location, this.keywords.toSet());
     }
 
     private Iterable<? extends LegendExecutionResult> generateDBFromConnection(SectionState section, String entityPath)

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/MappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/MappingLSPGrammarExtension.java
@@ -248,7 +248,7 @@ public class MappingLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
     @Override
     public Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
     {
-        String codeLine = section.getSection().getPrecedingText(location);
+        String codeLine = section.getSection().getLineUpTo(location);
         List<LegendCompletion> legendCompletions = Lists.mutable.empty();
 
         if (codeLine.isEmpty())

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/MappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/MappingLSPGrammarExtension.java
@@ -14,12 +14,20 @@
 
 package org.finos.legend.engine.ide.lsp.extension;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.lazy.CompositeIterable;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
@@ -43,13 +51,6 @@ import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.test.runner.mapping.MappingTestRunner;
 import org.finos.legend.engine.test.runner.mapping.RichMappingTestResult;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
-
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
 
 /**
  * Extension for the Mapping grammar.
@@ -206,7 +207,7 @@ public class MappingLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
                                 result.getException().printStackTrace(pw);
                             }
                         }
-                        results.add(LegendExecutionResult.newResult(Lists.mutable.of(entityPath, test.name),Type.ERROR, writer.toString()));
+                        results.add(LegendExecutionResult.newResult(Lists.mutable.of(entityPath, test.name), Type.ERROR, writer.toString()));
                         break;
                     }
                     default:
@@ -247,19 +248,18 @@ public class MappingLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
     @Override
     public Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
     {
-        String codeLine = section.getSection().getLine(location.getLine()).substring(0, location.getColumn());
+        String codeLine = section.getSection().getPrecedingText(location);
         List<LegendCompletion> legendCompletions = Lists.mutable.empty();
 
         if (codeLine.isEmpty())
         {
-            return BOILERPLATE_SUGGESTIONS.collect(s -> new LegendCompletion("Mapping boilerplate", s.replaceAll("\n",System.lineSeparator())));
+            BOILERPLATE_SUGGESTIONS.collect(s -> new LegendCompletion("Mapping boilerplate", s.replaceAll("\n", System.lineSeparator())), legendCompletions);
         }
-
-        if (STORE_OBJECT_TRIGGERS.anySatisfy(codeLine::endsWith))
+        else if (STORE_OBJECT_TRIGGERS.anySatisfy(codeLine::endsWith))
         {
             STORE_OBJECT_SUGGESTIONS.collect(s -> new LegendCompletion("Store object type", s), legendCompletions);
         }
 
-        return legendCompletions;
+        return CompositeIterable.with(legendCompletions, this.computeCompletionsForSupportedTypes(section, location, Set.of("Mapping")));
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
@@ -79,7 +79,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(PureLSPGrammarExtension.class);
 
-    private static final Set<String> TYPES = Set.of(
+    private static final Set<String> SUGGESTABLE_KEYWORDS = Set.of(
             "Association",
             "Class",
             "Enum",
@@ -89,7 +89,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
     );
 
     private static final List<String> KEYWORDS = List.copyOf(PrimitiveUtilities.getPrimitiveTypeNames().toSet()
-            .withAll(TYPES)
+            .withAll(SUGGESTABLE_KEYWORDS)
             .with("let")
             .with("native function")
     );
@@ -378,7 +378,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
             ATTRIBUTE_MULTIPLICITIES_SUGGESTIONS.collect(s -> new LegendCompletion("Attribute multiplicity", s), legendCompletions);
         }
 
-        return CompositeIterable.with(legendCompletions, this.computeCompletionsForSupportedTypes(section, location, TYPES));
+        return CompositeIterable.with(legendCompletions, this.computeCompletionsForSupportedTypes(section, location, SUGGESTABLE_KEYWORDS));
     }
 
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
@@ -19,10 +19,21 @@ import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.temporal.TemporalAccessor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.function.Consumer;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.lazy.CompositeIterable;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
@@ -61,16 +72,6 @@ import org.finos.legend.pure.m4.coreinstance.primitive.strictTime.PureStrictTime
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.time.temporal.TemporalAccessor;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.function.Consumer;
-
 /**
  * Extension for the Pure grammar.
  */
@@ -78,15 +79,19 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(PureLSPGrammarExtension.class);
 
+    private static final Set<String> TYPES = Set.of(
+            "Association",
+            "Class",
+            "Enum",
+            "function",
+            "import",
+            "Profile"
+    );
+
     private static final List<String> KEYWORDS = List.copyOf(PrimitiveUtilities.getPrimitiveTypeNames().toSet()
-            .with("Association")
-            .with("Class")
-            .with("Enum")
-            .with("function")
-            .with("import")
+            .withAll(TYPES)
             .with("let")
             .with("native function")
-            .with("Profile")
     );
 
     private static final ImmutableList<String> ATTRIBUTE_TYPES = PrimitiveUtilities.getPrimitiveTypeNames().collect(n -> n + " ", Lists.mutable.empty()).toImmutable();
@@ -138,8 +143,8 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
     public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs)
     {
         return EXEC_FUNCTION_ID.equals(commandId) ?
-               executeFunction(section, entityPath) :
-               super.execute(section, entityPath, commandId, executableArgs);
+                executeFunction(section, entityPath) :
+                super.execute(section, entityPath, commandId, executableArgs);
     }
 
     @Override
@@ -357,25 +362,23 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
     @Override
     public Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
     {
-        String codeLine = section.getSection().getLine(location.getLine()).substring(0, location.getColumn());
+        MutableList<LegendCompletion> legendCompletions = Lists.mutable.empty();
+        String codeLine = section.getSection().getPrecedingText(location);
 
         if (codeLine.isEmpty())
         {
-            return BOILERPLATE_SUGGESTIONS.collect(s -> new LegendCompletion("Pure boilerplate", s.replaceAll("\n",System.lineSeparator())));
+            BOILERPLATE_SUGGESTIONS.collect(s -> new LegendCompletion("Pure boilerplate", s.replaceAll("\n", System.lineSeparator())), legendCompletions);
         }
-
-        MutableList<LegendCompletion> legendCompletions = Lists.mutable.empty();
-
-        if (ATTRIBUTE_TYPES_TRIGGERS.anySatisfy(codeLine::endsWith))
+        else if (ATTRIBUTE_TYPES_TRIGGERS.anySatisfy(codeLine::endsWith))
         {
             ATTRIBUTE_TYPES_SUGGESTIONS.collect(s -> new LegendCompletion("Attribute type", s), legendCompletions);
         }
-        if (ATTRIBUTE_MULTIPLICITIES_TRIGGERS.anySatisfy(codeLine::endsWith))
+        else if (ATTRIBUTE_MULTIPLICITIES_TRIGGERS.anySatisfy(codeLine::endsWith))
         {
             ATTRIBUTE_MULTIPLICITIES_SUGGESTIONS.collect(s -> new LegendCompletion("Attribute multiplicity", s), legendCompletions);
         }
 
-        return legendCompletions;
+        return CompositeIterable.with(legendCompletions, this.computeCompletionsForSupportedTypes(section, location, TYPES));
     }
 
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
@@ -363,7 +363,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
     public Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
     {
         MutableList<LegendCompletion> legendCompletions = Lists.mutable.empty();
-        String codeLine = section.getSection().getPrecedingText(location);
+        String codeLine = section.getSection().getLineUpTo(location);
 
         if (codeLine.isEmpty())
         {

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/RuntimeLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/RuntimeLSPGrammarExtension.java
@@ -64,7 +64,7 @@ public class RuntimeLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
     @Override
     public Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
     {
-        String codeLine = section.getSection().getPrecedingText(location);
+        String codeLine = section.getSection().getLineUpTo(location);
         List<LegendCompletion> legendCompletions = Lists.mutable.empty();
 
         if (codeLine.isEmpty())

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/RuntimeLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/RuntimeLSPGrammarExtension.java
@@ -14,15 +14,16 @@
 
 package org.finos.legend.engine.ide.lsp.extension;
 
+import java.util.List;
+import java.util.Set;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
+import org.eclipse.collections.impl.lazy.CompositeIterable;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
 import org.finos.legend.engine.language.pure.grammar.from.runtime.RuntimeParser;
-
-import java.util.List;
 
 /**
  * Extension for the Runtime grammar.
@@ -63,13 +64,14 @@ public class RuntimeLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
     @Override
     public Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
     {
-        String codeLine = section.getSection().getLine(location.getLine()).substring(0, location.getColumn());
+        String codeLine = section.getSection().getPrecedingText(location);
+        List<LegendCompletion> legendCompletions = Lists.mutable.empty();
 
         if (codeLine.isEmpty())
         {
-            return BOILERPLATE_SUGGESTIONS.collect(s -> new LegendCompletion("Runtime boilerplate", s.replaceAll("\n",System.lineSeparator())));
+            BOILERPLATE_SUGGESTIONS.collect(s -> new LegendCompletion("Runtime boilerplate", s.replaceAll("\n",System.lineSeparator())), legendCompletions);
         }
 
-        return List.of();
+        return CompositeIterable.with(legendCompletions, this.computeCompletionsForSupportedTypes(section, location, Set.of("Runtime")));
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ServiceLSPGrammarExtension.java
@@ -102,7 +102,7 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
                     "  }\n" +
                     "}\n");
 
-    private volatile JsonMapper resultMapper;
+    private JsonMapper resultMapper;
 
     public ServiceLSPGrammarExtension()
     {

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ServiceLSPGrammarExtension.java
@@ -303,7 +303,7 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
     @Override
     public Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
     {
-        String codeLine = section.getSection().getPrecedingText(location);
+        String codeLine = section.getSection().getLineUpTo(location);
         List<LegendCompletion> legendCompletions = Lists.mutable.empty();
 
         if (codeLine.isEmpty())

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
@@ -14,6 +14,10 @@
 
 package org.finos.legend.engine.ide.lsp.extension;
 
+import java.util.Comparator;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
@@ -29,11 +33,6 @@ import org.finos.legend.engine.ide.lsp.extension.text.GrammarSection;
 import org.finos.legend.engine.ide.lsp.text.LineIndexedText;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Comparator;
-import java.util.function.Consumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 abstract class AbstractLSPGrammarExtensionTest<T extends LegendLSPGrammarExtension>
 {

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
@@ -35,11 +35,11 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-abstract class AbstractLSPGrammarExtensionTest
+abstract class AbstractLSPGrammarExtensionTest<T extends LegendLSPGrammarExtension>
 {
     private static final Pattern GRAMMAR_LINE_PATTERN = Pattern.compile("^\\h*+###(?<parser>\\w++)\\h*+$\\R?", Pattern.MULTILINE);
 
-    protected LegendLSPGrammarExtension extension = newExtension();
+    protected T extension = newExtension();
 
     @Test
     public void testDiagnostics_emptySection()
@@ -91,7 +91,7 @@ abstract class AbstractLSPGrammarExtensionTest
         return this.extension.execute(sectionState, entityPath, command, Maps.fixedSize.empty());
     }
 
-    protected abstract LegendLSPGrammarExtension newExtension();
+    protected abstract T newExtension();
 
     protected SectionState newSectionState(String docId, String text)
     {

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestConnectionLSPGrammarExtension.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 import static org.finos.legend.engine.ide.lsp.extension.ConnectionLSPGrammarExtension.GENERATE_DB_COMMAND_ID;
 
 
-public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
+public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensionTest<ConnectionLSPGrammarExtension>
 {
     @Test
     public void testGetName()
@@ -148,7 +148,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
     }
 
     @Override
-    protected LegendLSPGrammarExtension newExtension()
+    protected ConnectionLSPGrammarExtension newExtension()
     {
         return new ConnectionLSPGrammarExtension();
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestMappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestMappingLSPGrammarExtension.java
@@ -26,7 +26,7 @@ import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestMappingLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
+public class TestMappingLSPGrammarExtension extends AbstractLSPGrammarExtensionTest<MappingLSPGrammarExtension>
 {
     @Test
     public void testGetName()
@@ -115,7 +115,7 @@ public class TestMappingLSPGrammarExtension extends AbstractLSPGrammarExtensionT
     }
 
     @Override
-    protected LegendLSPGrammarExtension newExtension()
+    protected MappingLSPGrammarExtension newExtension()
     {
         return new MappingLSPGrammarExtension();
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestPureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestPureLSPGrammarExtension.java
@@ -24,7 +24,7 @@ import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.junit.jupiter.api.Test;
 
-public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
+public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest<PureLSPGrammarExtension>
 {
     @Test
     public void testGetName()
@@ -212,7 +212,7 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
     }
 
     @Override
-    protected LegendLSPGrammarExtension newExtension()
+    protected PureLSPGrammarExtension newExtension()
     {
         return new PureLSPGrammarExtension();
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestRelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestRelationalLSPGrammarExtension.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.engine.ide.lsp.extension;
 
+import java.util.Set;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.utility.Iterate;
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.finos.legend.engine.ide.lsp.extension.RelationalLSPGrammarExtension.GENERATE_MODEL_MAPPING_COMMAND_ID;
 
-public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
+public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensionTest<RelationalLSPGrammarExtension>
 {
     @Test
     public void testGetName()
@@ -272,8 +273,15 @@ public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensi
                 ")\n", result.getMessage());
     }
 
+    @Test
+    void testAntlrExpectedTokens()
+    {
+        Set<String> antlrExpectedTokens = this.extension.getAntlrExpectedTokens();
+        Assertions.assertEquals(Set.of("Database"), antlrExpectedTokens);
+    }
+
     @Override
-    protected LegendLSPGrammarExtension newExtension()
+    protected RelationalLSPGrammarExtension newExtension()
     {
         return new RelationalLSPGrammarExtension();
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestRuntimeLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestRuntimeLSPGrammarExtension.java
@@ -19,7 +19,7 @@ import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
 import org.junit.jupiter.api.Test;
 
-public class TestRuntimeLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
+public class TestRuntimeLSPGrammarExtension extends AbstractLSPGrammarExtensionTest<RuntimeLSPGrammarExtension>
 {
     @Test
     public void testGetName()
@@ -73,7 +73,7 @@ public class TestRuntimeLSPGrammarExtension extends AbstractLSPGrammarExtensionT
     }
 
     @Override
-    protected LegendLSPGrammarExtension newExtension()
+    protected RuntimeLSPGrammarExtension newExtension()
     {
         return new RuntimeLSPGrammarExtension();
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestServiceLSPGrammarExtension.java
@@ -14,14 +14,16 @@
 
 package org.finos.legend.engine.ide.lsp.extension;
 
+import java.util.Set;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
 import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
+public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionTest<ServiceLSPGrammarExtension>
 {
     @Test
     public void testGetName()
@@ -111,8 +113,15 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         );
     }
 
+    @Test
+    void testAntlrExpectedTokens()
+    {
+        Set<String> antlrExpectedTokens = this.extension.getAntlrExpectedTokens();
+        Assertions.assertEquals(Set.of("Service", "ExecutionEnvironment"), antlrExpectedTokens);
+    }
+
     @Override
-    protected LegendLSPGrammarExtension newExtension()
+    protected ServiceLSPGrammarExtension newExtension()
     {
         return new ServiceLSPGrammarExtension();
     }

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
@@ -61,6 +61,12 @@ public interface LegendLSPGrammarExtension extends LegendLSPExtension
         return Collections.emptyList();
     }
 
+    /**
+     * Return the completion suggestion base on section and location
+     * @param section grammar section state where completion triggered
+     * @param location location where completion triggered
+     * @return Completion suggestion contextual to section and location
+     */
     default Iterable<? extends LegendCompletion> getCompletions(SectionState section, TextPosition location)
     {
         return Collections.emptyList();

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/text/GrammarSection.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/text/GrammarSection.java
@@ -109,14 +109,24 @@ public interface GrammarSection
     }
 
     /**
-     * Get a single line of the section up to the column on the given position.
-     * @param position the position used to figure out what line number to extract, and up to what column
+     * Get a single line of the section up to the given position.  The column on the position determines the length of
+     * returned string (ie the position's column is not included)
+     * <p>
+     * This is similar to {@code this.getLine(position.geLine()).substring(0, position.getColumn())}
+     *
+     * @param position the position used to figure out what line number to extract, and the length of the line substring
      * @return section text between start of line and up to the position column
      * @throws IndexOutOfBoundsException if there is no such line in the section or column is bigger than line length
      */
-    default String getPrecedingText(TextPosition position)
+
+    default String getLineUpTo(TextPosition position)
     {
-        return getLine(position).substring(0, position.getColumn());
+        String lineContent = this.getLine(position.getLine());
+        if (position.getColumn() > lineContent.length())
+        {
+            throw new IndexOutOfBoundsException(String.format("Line %d length's %d is less than requested %d", position.getLine(), lineContent.length(), position.getColumn()));
+        }
+        return lineContent.substring(0, position.getColumn());
     }
 
     /**

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/text/GrammarSection.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/text/GrammarSection.java
@@ -98,6 +98,28 @@ public interface GrammarSection
     }
 
     /**
+     * Get a single line of the section.
+     * @param position the position used to figure out what line number to extract
+     * @return section line
+     * @throws IndexOutOfBoundsException if there is no such line in the section
+     */
+    default String getLine(TextPosition position)
+    {
+        return getLine(position.getLine());
+    }
+
+    /**
+     * Get a single line of the section up to the column on the given position.
+     * @param position the position used to figure out what line number to extract, and up to what column
+     * @return section text between start of line and up to the position column
+     * @throws IndexOutOfBoundsException if there is no such line in the section or column is bigger than line length
+     */
+    default String getPrecedingText(TextPosition position)
+    {
+        return getLine(position).substring(0, position.getColumn());
+    }
+
+    /**
      * Get a multi-line interval of the section text. Note that both {@code start} and {@code end} are inclusive.
      *
      * @param start start line (inclusive)

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/text/TextInterval.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/text/TextInterval.java
@@ -201,4 +201,10 @@ public class TextInterval
     {
         return newInterval(TextPosition.newPosition(startLine, startColumn), TextPosition.newPosition(endLine, endColumn));
     }
+
+    public boolean includes(TextPosition position)
+    {
+        return (this.start.equals(position) || this.start.isBefore(position))
+            && (this.end.equals(position) || this.end.isAfter(position));
+    }
 }

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/text/TextInterval.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/text/TextInterval.java
@@ -204,7 +204,6 @@ public class TextInterval
 
     public boolean includes(TextPosition position)
     {
-        return (this.start.equals(position) || this.start.isBefore(position))
-            && (this.end.equals(position) || this.end.isAfter(position));
+        return !position.isBefore(this.start) && !position.isAfter(this.end);
     }
 }

--- a/legend-engine-ide-lsp-extension-api/src/test/java/org/finos/legend/engine/ide/lsp/extension/text/TestTextInterval.java
+++ b/legend-engine-ide-lsp-extension-api/src/test/java/org/finos/legend/engine/ide/lsp/extension/text/TestTextInterval.java
@@ -78,6 +78,32 @@ public class TestTextInterval
         assertNotSubsumes(TextInterval.newInterval(1, 10, 5, 17), TextInterval.newInterval(0, 0, 1, 9), true);
     }
 
+    @Test
+    void includesPosition()
+    {
+        TextInterval textInterval = TextInterval.newInterval(2, 10, 5, 17);
+        Assertions.assertFalse(textInterval.includes(TextPosition.newPosition(1, 10)),
+                "should not be included as line is before start line");
+
+        Assertions.assertFalse(textInterval.includes(TextPosition.newPosition(2, 9)),
+                "should not be included as column is before start column");
+
+        Assertions.assertTrue(textInterval.includes(TextPosition.newPosition(2, 10)),
+                "should be included as position is equal as start of interval");
+
+        Assertions.assertTrue(textInterval.includes(TextPosition.newPosition(3, 15)),
+                "should be included as position is after start and before end of interval");
+
+        Assertions.assertTrue(textInterval.includes(TextPosition.newPosition(5, 17)),
+                "should be included as position is equal as end of interval");
+
+        Assertions.assertFalse(textInterval.includes(TextPosition.newPosition(5, 18)),
+                "should not be included as column is after interval end column");
+
+        Assertions.assertFalse(textInterval.includes(TextPosition.newPosition(6, 17)),
+                "should not be included as column is after interval end line");
+    }
+
     private void assertSubsumes(TextInterval interval1, TextInterval interval2)
     {
         assertSubsumes(interval1, interval2, false);

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
@@ -163,7 +163,7 @@ public class ClasspathUsingMavenFactory implements ClasspathFactory
                 request.setOutputHandler(new PrintStreamHandler(new PrintStream(this.outputStream, true), true));
                 request.setGoals(Collections.singletonList("dependency:build-classpath"));
                 request.setProperties(properties);
-                request.setTimeoutInSeconds((int) TimeUnit.MINUTES.toSeconds(5));
+                request.setTimeoutInSeconds((int) TimeUnit.MINUTES.toSeconds(15));
                 request.setJavaHome(Optional.ofNullable(System.getProperty("java.home")).map(File::new).orElse(null));
                 request.setMavenHome(maven);
                 request.setShowErrors(true);

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
@@ -459,7 +459,7 @@ class LegendTextDocumentService implements TextDocumentService
 
             List<LegendCompletion> completionItems = List.of();
 
-            String upToSuggestLocation = sectionState.getSection().getPrecedingText(location);
+            String upToSuggestLocation = sectionState.getSection().getLineUpTo(location);
             if (upToSuggestLocation.isEmpty() || upToSuggestLocation.startsWith("#"))
             {
                 completionItems = this.server.getGrammarLibrary()

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/TestLegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/TestLegendTextDocumentService.java
@@ -135,12 +135,7 @@ public class TestLegendTextDocumentService
         // with ###T preceding
         asserter.accept(new Position(9, 4), Set.of("TestGrammar", "EmptyGrammar"));
     }
-
-    private static void assertExpectedCompletionItems(String uri, TextDocumentService service, Position position, Set<String> expected) throws InterruptedException, ExecutionException
-    {
-
-    }
-
+    
     private static LegendLanguageServer newServer(LegendLSPGrammarExtension... extensions) throws ExecutionException, InterruptedException
     {
         LegendLanguageServer server = LegendLanguageServer.builder().synchronous().withGrammars(extensions).build();

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/TestLegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/TestLegendTextDocumentService.java
@@ -14,6 +14,15 @@
 
 package org.finos.legend.engine.ide.lsp.server;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.Position;
@@ -26,10 +35,6 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
 
 public class TestLegendTextDocumentService
 {
@@ -84,6 +89,56 @@ public class TestLegendTextDocumentService
         SemanticTokens semanticTokens = service.semanticTokensRange(new SemanticTokensRangeParams(new TextDocumentIdentifier(uri), newRange(2, 0, 9, 0))).get();
 
         Assertions.assertEquals(Collections.emptyList(), semanticTokens.getData());
+    }
+
+    @Test
+    void testDefaultCompletionsAdded() throws Exception
+    {
+        LegendLSPGrammarExtension extWithKeywords = newExtension("TestGrammar", Arrays.asList("Date", "Integer", "String", "Float", "StrictDate", "Boolean", "let", "true", "false"));
+        LegendLSPGrammarExtension extNoKeywords = newExtension("EmptyGrammar", Collections.emptyList());
+        LegendLanguageServer server = newServer(extWithKeywords, extNoKeywords);
+
+        String uri = "file:///testNoKeywordHighlighting.pure";
+        String code = "\r\n" +
+                "###EmptyGrammar\n" +
+                "Class vscodelsp::test::Employee\r\n" +
+                "{\n" +
+                "    id       : Integer[1];\n" +
+                "    hireDate : Date[1];\r\n" +
+                "    hireType : String[1];\n" +
+                "    employeeDetails : vscodelsp::test::EmployeeDetails[1];\n" +
+                "}\n" +
+                "###T\n";
+
+        TextDocumentService service = server.getTextDocumentService();
+        service.didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(uri, "", 0, code)));
+
+        BiConsumer<Position, Set<String>> asserter = (position, expected) ->
+        {
+            CompletionParams completionParams = new CompletionParams(
+                    new TextDocumentIdentifier(uri),
+                    position
+            );
+            List<CompletionItem> items = service.completion(completionParams).join().getLeft();
+            Assertions.assertEquals(2, items.size());
+            Assertions.assertEquals(expected, items.stream().map(CompletionItem::getLabel).collect(Collectors.toSet()));
+        };
+
+        // start of line
+        asserter.accept(new Position(9, 0), Set.of("###TestGrammar", "###EmptyGrammar"));
+        // with # preceding
+        asserter.accept(new Position(9, 1), Set.of("##TestGrammar", "##EmptyGrammar"));
+        // with ## preceding
+        asserter.accept(new Position(9, 2), Set.of("#TestGrammar", "#EmptyGrammar"));
+        // with ### preceding
+        asserter.accept(new Position(9, 3), Set.of("TestGrammar", "EmptyGrammar"));
+        // with ###T preceding
+        asserter.accept(new Position(9, 4), Set.of("TestGrammar", "EmptyGrammar"));
+    }
+
+    private static void assertExpectedCompletionItems(String uri, TextDocumentService service, Position position, Set<String> expected) throws InterruptedException, ExecutionException
+    {
+
     }
 
     private static LegendLanguageServer newServer(LegendLSPGrammarExtension... extensions) throws ExecutionException, InterruptedException

--- a/legend-engine-ide-lsp-text-tools/src/main/java/org/finos/legend/engine/ide/lsp/text/LineIndexedText.java
+++ b/legend-engine-ide-lsp-text-tools/src/main/java/org/finos/legend/engine/ide/lsp/text/LineIndexedText.java
@@ -269,9 +269,9 @@ public class LineIndexedText
      */
     public boolean isValidInterval(int startLine, int startColumn, int endLine, int endColumn)
     {
-        return (startLine == endLine) ?
-                isValidInterval(startLine, startColumn, endColumn) :
-                (startLine < endLine) && isValidColumn(startLine, startColumn) && isValidColumn(endLine, endColumn);
+        return (startLine == endLine && isValidInterval(startLine, startColumn, endColumn))
+                ||
+                ((startLine < endLine) && isValidColumn(startLine, startColumn) && isValidColumn(endLine, endColumn));
     }
 
     /**

--- a/legend-engine-ide-lsp-text-tools/src/main/java/org/finos/legend/engine/ide/lsp/text/LineIndexedText.java
+++ b/legend-engine-ide-lsp-text-tools/src/main/java/org/finos/legend/engine/ide/lsp/text/LineIndexedText.java
@@ -269,9 +269,9 @@ public class LineIndexedText
      */
     public boolean isValidInterval(int startLine, int startColumn, int endLine, int endColumn)
     {
-        return (startLine == endLine && isValidInterval(startLine, startColumn, endColumn))
-                ||
-                ((startLine < endLine) && isValidColumn(startLine, startColumn) && isValidColumn(endLine, endColumn));
+        return (startLine == endLine) ?
+                isValidInterval(startLine, startColumn, endColumn) :
+                (startLine < endLine) && isValidColumn(startLine, startColumn) && isValidColumn(endLine, endColumn);
     }
 
     /**


### PR DESCRIPTION
As part of completions, on empty lines, this will suggest the different grammars available (###Grammar), and also elements that grammar support, like Database within the Relational grammar.