### PR TITLE
Reduce synchronized blocks to improve concurrency

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -105,8 +105,16 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
     private final Map<Class<? extends PackageableElement>, String> classToClassifier = ProtocolToClassifierPathLoader.getProtocolClassToClassifierMap();
     private final LegendEngineServerClient engineServerClient = newEngineServerClient();
 
-    private volatile JsonMapper protocolMapper;
-    private volatile PureGrammarComposer composer;
+    private final JsonMapper protocolMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
+            .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+            .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+            .build());
+
+    private final PureGrammarComposer composer = PureGrammarComposer.newInstance(
+            PureGrammarComposerContext.Builder.newInstance()
+                    .withRenderStyle(RenderStyle.PRETTY)
+                    .build()
+    );
 
     @Override
     public void initialize(SectionState section)
@@ -506,13 +514,6 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
 
     private JsonMapper getProtocolMapper()
     {
-        if (this.protocolMapper == null)
-        {
-            this.protocolMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
-                    .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-                    .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
-                    .build());
-        }
         return this.protocolMapper;
     }
 
@@ -562,10 +563,6 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
 
     private PureGrammarComposer getComposer()
     {
-        if (this.composer == null)
-        {
-            this.composer = PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(RenderStyle.PRETTY).build());
-        }
         return this.composer;
     }
 

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -105,8 +105,8 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
     private final Map<Class<? extends PackageableElement>, String> classToClassifier = ProtocolToClassifierPathLoader.getProtocolClassToClassifierMap();
     private final LegendEngineServerClient engineServerClient = newEngineServerClient();
 
-    private JsonMapper protocolMapper;
-    private PureGrammarComposer composer;
+    private volatile JsonMapper protocolMapper;
+    private volatile PureGrammarComposer composer;
 
     @Override
     public void initialize(SectionState section)
@@ -506,17 +506,14 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
 
     private JsonMapper getProtocolMapper()
     {
-        synchronized (this)
+        if (this.protocolMapper == null)
         {
-            if (this.protocolMapper == null)
-            {
-                this.protocolMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
-                        .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-                        .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
-                        .build());
-            }
-            return this.protocolMapper;
+            this.protocolMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
+                    .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+                    .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+                    .build());
         }
+        return this.protocolMapper;
     }
 
     protected boolean isEngineServerConfigured()
@@ -565,14 +562,11 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
 
     private PureGrammarComposer getComposer()
     {
-        synchronized (this)
+        if (this.composer == null)
         {
-            if (this.composer == null)
-            {
-                this.composer = PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(RenderStyle.PRETTY).build());
-            }
-            return this.composer;
+            this.composer = PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().withRenderStyle(RenderStyle.PRETTY).build());
         }
+        return this.composer;
     }
 
     protected LegendDeclaration getDeclaration(PackageableElement element)

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
@@ -112,7 +112,13 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
     private static final String EXEC_FUNCTION_ID = "legend.pure.executeFunction";
     private static final String EXEC_FUNCTION_TITLE = "Execute function";
 
-    private volatile JsonMapper functionResultMapper;
+    private final JsonMapper functionResultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
+            .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+            .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .build());
 
     public PureLSPGrammarExtension()
     {
@@ -343,16 +349,6 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
 
     private JsonMapper getFunctionResultMapper()
     {
-        if (this.functionResultMapper == null)
-        {
-            this.functionResultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
-                    .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-                    .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
-                    .enable(SerializationFeature.INDENT_OUTPUT)
-                    .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-                    .serializationInclusion(JsonInclude.Include.NON_NULL)
-                    .build());
-        }
         return this.functionResultMapper;
     }
 

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/PureLSPGrammarExtension.java
@@ -112,7 +112,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
     private static final String EXEC_FUNCTION_ID = "legend.pure.executeFunction";
     private static final String EXEC_FUNCTION_TITLE = "Execute function";
 
-    private JsonMapper functionResultMapper;
+    private volatile JsonMapper functionResultMapper;
 
     public PureLSPGrammarExtension()
     {
@@ -343,20 +343,17 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
 
     private JsonMapper getFunctionResultMapper()
     {
-        synchronized (this)
+        if (this.functionResultMapper == null)
         {
-            if (this.functionResultMapper == null)
-            {
-                this.functionResultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
-                        .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-                        .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
-                        .enable(SerializationFeature.INDENT_OUTPUT)
-                        .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-                        .serializationInclusion(JsonInclude.Include.NON_NULL)
-                        .build());
-            }
-            return this.functionResultMapper;
+            this.functionResultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
+                    .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+                    .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                    .serializationInclusion(JsonInclude.Include.NON_NULL)
+                    .build());
         }
+        return this.functionResultMapper;
     }
 
     @Override

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ServiceLSPGrammarExtension.java
@@ -102,7 +102,13 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
                     "  }\n" +
                     "}\n");
 
-    private volatile JsonMapper resultMapper;
+    private final JsonMapper resultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
+            .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+            .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .build());
 
     public ServiceLSPGrammarExtension()
     {
@@ -284,16 +290,6 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
 
     private JsonMapper getResultMapper()
     {
-        if (this.resultMapper == null)
-        {
-            this.resultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
-                    .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-                    .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
-                    .enable(SerializationFeature.INDENT_OUTPUT)
-                    .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-                    .serializationInclusion(JsonInclude.Include.NON_NULL)
-                    .build());
-        }
         return this.resultMapper;
     }
 

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/ServiceLSPGrammarExtension.java
@@ -102,7 +102,7 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
                     "  }\n" +
                     "}\n");
 
-    private JsonMapper resultMapper;
+    private volatile JsonMapper resultMapper;
 
     public ServiceLSPGrammarExtension()
     {
@@ -284,20 +284,17 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
 
     private JsonMapper getResultMapper()
     {
-        synchronized (this)
+        if (this.resultMapper == null)
         {
-            if (this.resultMapper == null)
-            {
-                this.resultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
-                        .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-                        .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
-                        .enable(SerializationFeature.INDENT_OUTPUT)
-                        .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-                        .serializationInclusion(JsonInclude.Include.NON_NULL)
-                        .build());
-            }
-            return this.resultMapper;
+            this.resultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
+                    .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+                    .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+                    .enable(SerializationFeature.INDENT_OUTPUT)
+                    .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                    .serializationInclusion(JsonInclude.Include.NON_NULL)
+                    .build());
         }
+        return this.resultMapper;
     }
 
     @Override

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/AbstractState.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/AbstractState.java
@@ -14,43 +14,43 @@
 
 package org.finos.legend.engine.ide.lsp.server;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.finos.legend.engine.ide.lsp.extension.state.State;
 
 abstract class AbstractState implements State
 {
-    private final ConcurrentMap<String, Object> properties = new ConcurrentHashMap<>();
+    private final Map<String, Object> properties = new HashMap<>();
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T getProperty(String key)
+    public synchronized <T> T getProperty(String key)
     {
         return (T) this.properties.get(key);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T getProperty(String key, Supplier<? extends T> supplier)
+    public synchronized <T> T getProperty(String key, Supplier<? extends T> supplier)
     {
         return (T) this.properties.computeIfAbsent(key, k -> supplier.get());
     }
 
     @Override
-    public void setProperty(String key, Object value)
+    public synchronized void setProperty(String key, Object value)
     {
         this.properties.compute(key, (x, y) -> value);
     }
 
     @Override
-    public void removeProperty(String key)
+    public synchronized void removeProperty(String key)
     {
         this.properties.remove(key);
     }
 
     @Override
-    public void clearProperties()
+    public synchronized void clearProperties()
     {
         this.properties.clear();
     }

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendServerGlobalState.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendServerGlobalState.java
@@ -23,9 +23,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
@@ -41,7 +41,7 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(LegendServerGlobalState.class);
 
-    private final ConcurrentMap<String, LegendServerDocumentState> docs = new ConcurrentHashMap<>();
+    private final Map<String, LegendServerDocumentState> docs = new HashMap<>();
     private final LegendLanguageServer server;
 
     LegendServerGlobalState(LegendLanguageServer server)
@@ -51,13 +51,13 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
     }
 
     @Override
-    public LegendServerDocumentState getDocumentState(String id)
+    public synchronized LegendServerDocumentState getDocumentState(String id)
     {
         return this.docs.get(id);
     }
 
     @Override
-    public void forEachDocumentState(Consumer<? super DocumentState> consumer)
+    public synchronized void forEachDocumentState(Consumer<? super DocumentState> consumer)
     {
         this.docs.values().forEach(consumer);
     }
@@ -80,12 +80,12 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
         this.server.logErrorToClient(message);
     }
 
-    LegendServerDocumentState getOrCreateDocState(String uri)
+    synchronized LegendServerDocumentState getOrCreateDocState(String uri)
     {
         return this.docs.computeIfAbsent(uri, k -> new LegendServerDocumentState(this, uri));
     }
 
-    void deleteDocState(String uri)
+    synchronized void deleteDocState(String uri)
     {
         this.docs.remove(uri);
         this.clearProperties();

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendServerGlobalState.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendServerGlobalState.java
@@ -14,15 +14,6 @@
 
 package org.finos.legend.engine.ide.lsp.server;
 
-import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
-import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
-import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
-import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
-import org.finos.legend.engine.ide.lsp.extension.text.GrammarSection;
-import org.finos.legend.engine.ide.lsp.text.GrammarSectionIndex;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -32,17 +23,25 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
+import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
+import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
+import org.finos.legend.engine.ide.lsp.extension.text.GrammarSection;
+import org.finos.legend.engine.ide.lsp.text.GrammarSectionIndex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class LegendServerGlobalState extends AbstractState implements GlobalState
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(LegendServerGlobalState.class);
 
-    private final Map<String, LegendServerDocumentState> docs = new HashMap<>();
+    private final ConcurrentMap<String, LegendServerDocumentState> docs = new ConcurrentHashMap<>();
     private final LegendLanguageServer server;
 
     LegendServerGlobalState(LegendLanguageServer server)
@@ -54,19 +53,13 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
     @Override
     public LegendServerDocumentState getDocumentState(String id)
     {
-        synchronized (this.lock)
-        {
-            return this.docs.get(id);
-        }
+        return this.docs.get(id);
     }
 
     @Override
     public void forEachDocumentState(Consumer<? super DocumentState> consumer)
     {
-        synchronized (this.lock)
-        {
-            this.docs.values().forEach(consumer);
-        }
+        this.docs.values().forEach(consumer);
     }
 
     @Override
@@ -89,68 +82,58 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
 
     LegendServerDocumentState getOrCreateDocState(String uri)
     {
-        synchronized (this.lock)
-        {
-            return this.docs.computeIfAbsent(uri, k -> new LegendServerDocumentState(this, uri));
-        }
+        return this.docs.computeIfAbsent(uri, k -> new LegendServerDocumentState(this, uri));
     }
 
     void deleteDocState(String uri)
     {
-        synchronized (this.lock)
-        {
-            this.docs.remove(uri);
-        }
+        this.docs.remove(uri);
+        this.clearProperties();
     }
 
-    void renameDoc(String oldUri, String newUri)
+    synchronized void renameDoc(String oldUri, String newUri)
     {
-        synchronized (this.lock)
+        if (this.docs.containsKey(newUri))
         {
-            if (this.docs.containsKey(newUri))
-            {
-                throw new IllegalStateException("Cannot rename " + oldUri + " to " + newUri + ": file already exists");
-            }
+            throw new IllegalStateException("Cannot rename " + oldUri + " to " + newUri + ": file already exists");
+        }
 
-            LegendServerDocumentState oldState = this.docs.remove(oldUri);
-            if (oldState != null)
-            {
-                LegendServerDocumentState newState = new LegendServerDocumentState(this, newUri);
-                newState.version = oldState.version;
-                newState.sectionIndex = oldState.sectionIndex;
-                newState.sectionStates = newState.createSectionStates(newState.sectionIndex);
-                this.docs.put(newUri, newState);
-            }
+        LegendServerDocumentState oldState = this.docs.remove(oldUri);
+        if (oldState != null)
+        {
+            LegendServerDocumentState newState = new LegendServerDocumentState(this, newUri);
+            newState.version = oldState.version;
+            newState.sectionIndex = oldState.sectionIndex;
+            newState.sectionStates = newState.createSectionStates(newState.sectionIndex);
+            this.docs.put(newUri, newState);
         }
     }
 
-    void addFolder(String folderUri)
+    synchronized void addFolder(String folderUri)
     {
         try
         {
             Path folderPath = Paths.get(URI.create(folderUri));
-            synchronized (this.lock)
+            try (Stream<Path> stream = Files.find(folderPath, Integer.MAX_VALUE,
+                    (path, attr) -> attr.isRegularFile() && path.getFileName().toString().endsWith(".pure"),
+                    FileVisitOption.FOLLOW_LINKS))
             {
-                try (Stream<Path> stream = Files.find(folderPath, Integer.MAX_VALUE,
-                        (path, attr) -> attr.isRegularFile() && path.getFileName().toString().endsWith(".pure"),
-                        FileVisitOption.FOLLOW_LINKS))
+                stream.forEach(path ->
                 {
-                    stream.forEach(path ->
+                    StringBuilder builder = new StringBuilder(folderUri);
+                    folderPath.relativize(path).forEach(p ->
                     {
-                        StringBuilder builder = new StringBuilder(folderUri);
-                        folderPath.relativize(path).forEach(p ->
+                        if (builder.charAt(builder.length() - 1) != '/')
                         {
-                            if (builder.charAt(builder.length() - 1) != '/')
-                            {
-                                builder.append('/');
-                            }
-                            builder.append(URLEncoder.encode(p.toString(), StandardCharsets.UTF_8));
-                        });
-                        LegendServerDocumentState docState = getOrCreateDocState(builder.toString());
-                        docState.initialize();
+                            builder.append('/');
+                        }
+                        builder.append(URLEncoder.encode(p.toString(), StandardCharsets.UTF_8));
                     });
-                }
+                    LegendServerDocumentState docState = getOrCreateDocState(builder.toString());
+                    docState.initialize();
+                });
             }
+            this.clearProperties();
         }
         catch (Exception e)
         {
@@ -158,12 +141,10 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
         }
     }
 
-    void removeFolder(String folderUri)
+    synchronized void removeFolder(String folderUri)
     {
-        synchronized (this.lock)
-        {
-            this.docs.keySet().removeIf(uri -> uri.startsWith(folderUri));
-        }
+        this.docs.keySet().removeIf(uri -> uri.startsWith(folderUri));
+        this.clearProperties();
     }
 
     static class LegendServerDocumentState extends AbstractState implements DocumentState
@@ -176,7 +157,6 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
 
         private LegendServerDocumentState(LegendServerGlobalState globalState, String uri)
         {
-            super(globalState);
             this.globalState = globalState;
             this.uri = uri;
         }
@@ -194,195 +174,144 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
         }
 
         @Override
-        public String getText()
+        public synchronized String getText()
         {
-            synchronized (this.lock)
-            {
-                return (this.sectionIndex == null) ? null : this.sectionIndex.getText();
-            }
+            return (this.sectionIndex == null) ? null : this.sectionIndex.getText();
         }
 
         @Override
-        public int getLineCount()
+        public synchronized int getLineCount()
         {
-            synchronized (this.lock)
-            {
-                return (this.sectionIndex == null) ? 0 : this.sectionIndex.getLineCount();
-            }
+            return (this.sectionIndex == null) ? 0 : this.sectionIndex.getLineCount();
         }
 
         @Override
-        public String getLine(int line)
+        public synchronized String getLine(int line)
         {
-            synchronized (this.lock)
-            {
-                return (this.sectionIndex == null) ? null : this.sectionIndex.getLine(line);
-            }
+            return (this.sectionIndex == null) ? null : this.sectionIndex.getLine(line);
         }
 
         @Override
-        public String getLines(int start, int end)
+        public synchronized String getLines(int start, int end)
         {
-            synchronized (this.lock)
-            {
-                return (this.sectionIndex == null) ? null : this.sectionIndex.getLines(start, end);
-            }
+            return (this.sectionIndex == null) ? null : this.sectionIndex.getLines(start, end);
         }
 
         @Override
-        public int getSectionCount()
+        public synchronized int getSectionCount()
         {
-            synchronized (this.lock)
-            {
-                return this.sectionStates.size();
-            }
+            return this.sectionStates.size();
         }
 
         @Override
-        public SectionState getSectionState(int n)
+        public synchronized SectionState getSectionState(int n)
         {
-            synchronized (this.lock)
-            {
-                return this.sectionStates.get(n);
-            }
+            return this.sectionStates.get(n);
         }
 
         @Override
-        public SectionState getSectionStateAtLine(int line)
+        public synchronized SectionState getSectionStateAtLine(int line)
         {
-            synchronized (this.lock)
+            if (this.sectionIndex != null)
             {
-                if (this.sectionIndex != null)
+                int n = this.sectionIndex.getSectionNumberAtLine(line);
+                if (n != -1)
                 {
-                    int n = this.sectionIndex.getSectionNumberAtLine(line);
-                    if (n != -1)
-                    {
-                        return this.sectionStates.get(n);
-                    }
+                    return this.sectionStates.get(n);
                 }
-                return null;
             }
+            return null;
         }
 
         @Override
-        public void forEachSectionState(Consumer<? super SectionState> consumer)
+        public synchronized void forEachSectionState(Consumer<? super SectionState> consumer)
         {
-            synchronized (this.lock)
-            {
-                this.sectionStates.forEach(consumer);
-            }
+            this.sectionStates.forEach(consumer);
         }
 
-        boolean isInitialized()
+        synchronized boolean isInitialized()
         {
-            synchronized (this.lock)
-            {
-                return this.sectionStates != null;
-            }
+            return this.sectionStates != null;
         }
 
-        boolean isOpen()
+        synchronized boolean isOpen()
         {
-            synchronized (this.lock)
-            {
-                return this.version != null;
-            }
+            return this.version != null;
         }
 
-        void open(int version, String text)
+        synchronized void open(int version, String text)
         {
-            synchronized (this.lock)
+            if (this.version != null)
             {
-                if (this.version != null)
-                {
-                    LOGGER.warn("{} already opened at version {}: overwriting with version {}", this.uri, this.version, version);
-                }
-                this.version = version;
-                setText(text);
+                LOGGER.warn("{} already opened at version {}: overwriting with version {}", this.uri, this.version, version);
             }
+            this.version = version;
+            setText(text);
         }
 
-        void close()
+        synchronized void close()
         {
-            synchronized (this.lock)
-            {
-                this.version = null;
-            }
+            this.version = null;
         }
 
-        void change(int newVersion)
+        synchronized void change(int newVersion)
         {
-            synchronized (this.lock)
+            if ((this.version != null) && (newVersion < this.version))
             {
-                if ((this.version != null) && (newVersion < this.version))
-                {
-                    LOGGER.warn("Changing {} from version {} to {}", this.uri, this.version, newVersion);
-                }
-                this.version = newVersion;
+                LOGGER.warn("Changing {} from version {} to {}", this.uri, this.version, newVersion);
             }
+            this.version = newVersion;
         }
 
-        void change(int newVersion, String newText)
+        synchronized void change(int newVersion, String newText)
         {
-            synchronized (this.lock)
+            if ((this.version != null) && (newVersion <= this.version))
             {
-                if ((this.version != null) && (newVersion <= this.version))
-                {
-                    LOGGER.warn("Changing {} from version {} to {}", this.uri, this.version, newVersion);
-                }
-                this.version = newVersion;
-                setText(newText);
+                LOGGER.warn("Changing {} from version {} to {}", this.uri, this.version, newVersion);
             }
+            this.version = newVersion;
+            setText(newText);
         }
 
-        void save(String text)
+        synchronized void save(String text)
         {
             if (text != null)
             {
-                synchronized (this.lock)
-                {
-                    setText(text);
-                }
-            }
-        }
-
-        void initialize()
-        {
-            synchronized (this.lock)
-            {
-                if (!isInitialized())
-                {
-                    String message = "Initializing file: " + this.uri;
-                    this.globalState.server.logInfoToClient(message);
-                    LOGGER.debug(message);
-                    loadText();
-                }
-            }
-        }
-
-        void loadText()
-        {
-            synchronized (this.lock)
-            {
-                String text;
-                try
-                {
-                    Path path = Paths.get(URI.create(this.uri));
-                    text = Files.readString(path);
-                }
-                catch (Exception e)
-                {
-                    LOGGER.warn("Error loading text for {}", this.uri, e);
-                    this.globalState.server.logWarningToClient("Error loading text for " + this.uri + ((e.getMessage() == null) ? "" : (": " + e.getMessage())));
-                    return;
-                }
-
-                this.version = null;
                 setText(text);
             }
         }
 
-        private void setText(String newText)
+        synchronized void initialize()
+        {
+            if (!isInitialized())
+            {
+                String message = "Initializing file: " + this.uri;
+                this.globalState.server.logInfoToClient(message);
+                LOGGER.debug(message);
+                loadText();
+            }
+        }
+
+        synchronized void loadText()
+        {
+            String text;
+            try
+            {
+                Path path = Paths.get(URI.create(this.uri));
+                text = Files.readString(path);
+            }
+            catch (Exception e)
+            {
+                LOGGER.warn("Error loading text for {}", this.uri, e);
+                this.globalState.server.logWarningToClient("Error loading text for " + this.uri + ((e.getMessage() == null) ? "" : (": " + e.getMessage())));
+                return;
+            }
+
+            this.version = null;
+            setText(text);
+        }
+
+        private synchronized void setText(String newText)
         {
             if ((this.sectionIndex == null) ? (newText == null) : this.sectionIndex.getText().equals(newText))
             {
@@ -391,22 +320,25 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
             }
 
             logInfo("Clearing global and " + this.uri + " properties");
-            clearProperties();
-            this.globalState.clearProperties();
             this.sectionIndex = (newText == null) ? null : GrammarSectionIndex.parse(newText);
             this.sectionStates = createSectionStates(this.sectionIndex);
+            this.clearProperties();
         }
 
-        public void recreateSectionStates()
+        public synchronized void recreateSectionStates()
         {
-            synchronized (this.lock)
-            {
-                this.globalState.clearProperties();
-                this.sectionStates = createSectionStates(this.sectionIndex);
-            }
+            this.sectionStates = createSectionStates(this.sectionIndex);
+            this.clearProperties();
         }
 
-        private List<LegendServerSectionState> createSectionStates(GrammarSectionIndex index)
+        @Override
+        public synchronized void clearProperties()
+        {
+            super.clearProperties();
+            this.globalState.clearProperties();
+        }
+
+        private synchronized List<LegendServerSectionState> createSectionStates(GrammarSectionIndex index)
         {
             if (index == null)
             {
@@ -449,7 +381,6 @@ class LegendServerGlobalState extends AbstractState implements GlobalState
 
         private LegendServerSectionState(LegendServerDocumentState docState, int n, GrammarSection grammarSection, LegendLSPGrammarExtension extension)
         {
-            super(docState.lock);
             this.docState = docState;
             this.n = n;
             this.grammarSection = grammarSection;


### PR DESCRIPTION
This PR leaves the synchronization to the `LegendServerDocumentState`, rather than on the `LegendServerGlobalState`.

This will allow more concurrency on actions that are outside of a document, or allow multiple documents to answer for the different client request.

This also trigger a compilation during the initialization, absorbing some one-time costs to this step, rather than blocking the user during their initial interactions.

