### PR TITLE
Extensions API to provide references

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/pom.xml
+++ b/legend-engine-ide-lsp-default-extensions/pom.xml
@@ -27,7 +27,7 @@
     <name>Legend Engine IDE LSP Default Extensions</name>
 
     <properties>
-        <legend.engine.version>4.37.0</legend.engine.version>
+        <legend.engine.version>4.37.7</legend.engine.version>
     </properties>
 
     <build>

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
@@ -44,15 +46,16 @@ import org.finos.legend.engine.ide.lsp.extension.execution.LegendCommand;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult.Type;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendInputParamter;
+import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
 import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.GrammarSection;
-import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
-import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.language.pure.compiler.Compiler;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.SourceInformationHelper;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.Warning;
 import org.finos.legend.engine.language.pure.grammar.from.ParseTreeWalkerSourceInformation;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserContext;
@@ -60,7 +63,6 @@ import org.finos.legend.engine.language.pure.grammar.from.SectionSourceCode;
 import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
 import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposer;
 import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
-import org.finos.legend.engine.language.pure.modelManager.ModelManager;
 import org.finos.legend.engine.protocol.pure.v1.ProtocolToClassifierPathLoader;
 import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
@@ -101,6 +103,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
     private static final String TEST_ID = "legend.testable.testId";
 
     private static final String PARSE_RESULT = "parse";
+    private static final String REFERENCE_RESULT = "reference";
     private static final String COMPILE_RESULT = "compile";
 
     private final Map<String, ? extends TestableRunnerExtension> testableRunners = TestableRunnerExtensionLoader.getClassifierPathToTestableRunnerMap();
@@ -157,7 +160,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
             SourceInformation sourceInfo = e.getSourceInformation();
             if (isValidSourceInfo(sourceInfo))
             {
-                consumer.accept(LegendDiagnostic.newDiagnostic(toLocation(sourceInfo), e.getMessage(), LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Parser));
+                consumer.accept(LegendDiagnostic.newDiagnostic(SourceInformationUtil.toLocation(sourceInfo), e.getMessage(), LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Parser));
             }
             else
             {
@@ -183,7 +186,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
             }
             else if (docId.equals(sourceInfo.sourceId))
             {
-                consumer.accept(LegendDiagnostic.newDiagnostic(toLocation(sourceInfo), e.getMessage(), LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Compiler));
+                consumer.accept(LegendDiagnostic.newDiagnostic(SourceInformationUtil.toLocation(sourceInfo), e.getMessage(), LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Compiler));
             }
         }
         if (compileResult.getPureModel() != null)
@@ -202,7 +205,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
                 }
                 else if (docId.equals(sourceInfo.sourceId))
                 {
-                    consumer.accept(LegendDiagnostic.newDiagnostic(toLocation(sourceInfo), warning.message, LegendDiagnostic.Kind.Warning, LegendDiagnostic.Source.Compiler));
+                    consumer.accept(LegendDiagnostic.newDiagnostic(SourceInformationUtil.toLocation(sourceInfo), warning.message, LegendDiagnostic.Kind.Warning, LegendDiagnostic.Source.Compiler));
                 }
             });
         }
@@ -225,7 +228,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
             {
                 if (isValidSourceInfo(sourceInfo))
                 {
-                    commands.add(LegendCommand.newCommand(path, id, title, toLocation(sourceInfo), args, inputParameters));
+                    commands.add(LegendCommand.newCommand(path, id, title, SourceInformationUtil.toLocation(sourceInfo), args, inputParameters));
                 }
             });
         });
@@ -336,7 +339,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
 
         try
         {
-            TestableRunner runner = new TestableRunner(new ModelManager(DeploymentMode.PROD));
+            TestableRunner runner = new TestableRunner();
             RunTestsTestableInput runTestsTestableInput = new RunTestsTestableInput();
             runTestsTestableInput.testable = entityPath;
             runTestsTestableInput.unitTestIds = unitTestIds;
@@ -467,7 +470,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
             SourceInformation sourceInfo = e.getSourceInformation();
             if (isValidSourceInfo(sourceInfo))
             {
-                globalState.logInfo("Compilation completed with error " + "(" + sourceInfo.sourceId + " " + toLocation(sourceInfo) + "): " + e.getMessage());
+                globalState.logInfo("Compilation completed with error " + "(" + sourceInfo.sourceId + " " + SourceInformationUtil.toLocation(sourceInfo) + "): " + e.getMessage());
             }
             else
             {
@@ -593,7 +596,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
         LegendDeclaration.Builder builder = LegendDeclaration.builder()
                 .withIdentifier(path)
                 .withClassifier(classifier)
-                .withLocation(toLocation(element.sourceInformation));
+                .withLocation(SourceInformationUtil.toLocation(element.sourceInformation));
         forEachChild(element, c -> addChildIfNonNull(builder, c));
         return builder.build();
     }
@@ -643,7 +646,7 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
 
     private boolean isPositionIncludedOnSourceInfo(TextPosition position, SourceInformation sourceInformation)
     {
-        return isValidSourceInfo(sourceInformation) && toLocation(sourceInformation).getTextInterval().includes(position);
+        return isValidSourceInfo(sourceInformation) && SourceInformationUtil.toLocation(sourceInformation).getTextInterval().includes(position);
     }
 
     /**
@@ -659,17 +662,6 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
                 (sourceInfo.startColumn > 0) &&
                 (sourceInfo.startLine <= sourceInfo.endLine) &&
                 ((sourceInfo.startLine == sourceInfo.endLine) ? (sourceInfo.startColumn <= sourceInfo.endColumn) : (sourceInfo.endColumn > 0));
-    }
-
-    /**
-     * Transform a (valid) {@link SourceInformation} to a {@link TextInterval} location.
-     *
-     * @param sourceInfo source information
-     * @return location
-     */
-    protected static TextLocation toLocation(SourceInformation sourceInfo)
-    {
-        return TextLocation.newTextSource(sourceInfo.sourceId, sourceInfo.startLine - 1, sourceInfo.startColumn - 1, sourceInfo.endLine - 1, sourceInfo.endColumn - 1);
     }
 
     protected Iterable<LegendCompletion> computeCompletionsForSupportedTypes(SectionState section, TextPosition location, Set<String> supportedTypes)
@@ -688,6 +680,49 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
         return List.of();
     }
 
+    @Override
+    public Optional<LegendReference> getLegendReference(SectionState section, TextPosition textPosition)
+    {
+        Optional<PackageableElement> elementAtPosition = this.getElementAtPosition(section, textPosition);
+
+        return elementAtPosition.flatMap(pe -> this.geReferenceResolversResult(section, pe)
+                        .stream()
+                        .filter(ref -> ref.getLocation().getTextInterval().includes(textPosition))
+                        .findAny()
+                )
+                .flatMap(reference ->
+                        Optional.of(this.getCompileResult(section))
+                                .map(CompileResult::getPureModel)
+                                .map(x -> x.getContext(elementAtPosition.get()))
+                                .flatMap(reference::goToReferenced)
+                                .map(coreInstance ->
+                                {
+                                    SourceInformation sourceInfo = SourceInformationHelper.fromM3SourceInformation(coreInstance.getSourceInformation());
+                                    if (isValidSourceInfo(sourceInfo))
+                                    {
+                                        TextLocation declarationLocation = SourceInformationUtil.toLocation(sourceInfo);
+                                        return LegendReference.builder()
+                                                .withLocation(reference.getLocation())
+                                                .withReferencedLocation(declarationLocation)
+                                                .build();
+                                    }
+
+                                    LOGGER.warn("Reference points to an element without source information");
+
+                                    return null;
+                                }));
+    }
+
+    private Collection<LegendReferenceResolver> geReferenceResolversResult(SectionState section, PackageableElement packageableElement)
+    {
+        return section.getProperty(REFERENCE_RESULT + ":" + packageableElement.getPath(), () -> getReferenceResolvers(section, packageableElement));
+    }
+
+    protected Collection<LegendReferenceResolver> getReferenceResolvers(SectionState section, PackageableElement packageableElement)
+    {
+        return List.of();
+    }
+
     private static LegendEngineServerClient newEngineServerClient()
     {
         for (LegendEngineServerClient client : ServiceLoader.load(LegendEngineServerClient.class))
@@ -700,6 +735,14 @@ abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExtension
         }
         LOGGER.debug("Using default Legend Engine server client");
         return new DefaultLegendEngineServerClient();
+    }
+
+    public <T> Stream<? extends T> findExtensionThatImplements(GlobalState state, Class<T> _interface)
+    {
+        return state.getAvailableGrammarExtensions()
+                .stream()
+                .filter(_interface::isInstance)
+                .map(_interface::cast);
     }
 
     protected static class Result<T>

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLegacyParserLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLegacyParserLSPGrammarExtension.java
@@ -21,7 +21,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.Package
 
 import java.util.function.Consumer;
 
-abstract class AbstractLegacyParserLSPGrammarExtension extends AbstractLSPGrammarExtension
+public abstract class AbstractLegacyParserLSPGrammarExtension extends AbstractLSPGrammarExtension
 {
     protected final DEPRECATED_SectionGrammarParser parser;
 

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractSectionParserLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractSectionParserLSPGrammarExtension.java
@@ -39,7 +39,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 
-abstract class AbstractSectionParserLSPGrammarExtension extends AbstractLSPGrammarExtension
+public abstract class AbstractSectionParserLSPGrammarExtension extends AbstractLSPGrammarExtension
 {
     protected final SectionParser parser;
     private final Set<String> grammarSupportedTypes;
@@ -101,7 +101,7 @@ abstract class AbstractSectionParserLSPGrammarExtension extends AbstractLSPGramm
         return this.computeCompletionsForSupportedTypes(section, location, this.grammarSupportedTypes);
     }
 
-    protected Set<String> getAntlrExpectedTokens()
+    public Set<String> getAntlrExpectedTokens()
     {
         Set<String> expectedTokens = Collections.emptySet();
 

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendReferenceResolver.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendReferenceResolver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import org.finos.legend.engine.ide.lsp.extension.text.Locatable;
+import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.pure.m4.coreinstance.CoreInstance;
+
+public class LegendReferenceResolver implements Locatable
+{
+    private final TextLocation location;
+    private final Function<CompileContext, CoreInstance> gotoResolver;
+
+    private LegendReferenceResolver(TextLocation location, Function<CompileContext, CoreInstance> gotoResolver)
+    {
+        this.location = Objects.requireNonNull(location);
+        this.gotoResolver = Objects.requireNonNull(gotoResolver);
+    }
+
+    @Override
+    public TextLocation getLocation()
+    {
+        return location;
+    }
+
+    Optional<CoreInstance> goToReferenced(CompileContext compileContext)
+    {
+        try
+        {
+            return Optional.ofNullable(this.gotoResolver.apply(compileContext));
+        }
+        catch (Exception e)
+        {
+            return Optional.empty();
+        }
+    }
+
+    public static LegendReferenceResolver newReferenceResolver(SourceInformation location, Function<CompileContext, CoreInstance> gotoResolver)
+    {
+        return new LegendReferenceResolver(SourceInformationUtil.toLocation(location), gotoResolver);
+    }
+}

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/SourceInformationUtil.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/SourceInformationUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension;
+
+import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
+import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+
+public final class SourceInformationUtil
+{
+    private SourceInformationUtil()
+    {
+
+    }
+
+    /**
+     * Transform a (valid) {@link SourceInformation} to a {@link TextInterval} location.
+     *
+     * @param sourceInfo source information
+     * @return location
+     */
+    public static TextLocation toLocation(SourceInformation sourceInfo)
+    {
+        return TextLocation.newTextSource(sourceInfo.sourceId, sourceInfo.startLine - 1, sourceInfo.startColumn - 1, sourceInfo.endLine - 1, sourceInfo.endColumn - 1);
+    }
+}

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
@@ -1,18 +1,20 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.connection;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
@@ -22,6 +24,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.set.MutableSet;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLegacyParserLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult.Type;

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PureLSPGrammarExtension.java
@@ -1,18 +1,20 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.core;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.StreamReadFeature;
@@ -37,6 +39,8 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.lazy.CompositeIterable;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.utility.Iterate;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLegacyParserLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.SourceInformationUtil;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
@@ -229,7 +233,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
                     consumer.accept(LegendDeclaration.builder()
                             .withIdentifier(value.value)
                             .withClassifier(path)
-                            .withLocation(toLocation(value.sourceInformation))
+                            .withLocation(SourceInformationUtil.toLocation(value.sourceInformation))
                             .build());
                 }
             });
@@ -253,7 +257,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
         return LegendDeclaration.builder()
                 .withIdentifier(property.name)
                 .withClassifier(M3Paths.Property)
-                .withLocation(toLocation(property.sourceInformation))
+                .withLocation(SourceInformationUtil.toLocation(property.sourceInformation))
                 .build();
     }
 
@@ -295,7 +299,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
         return LegendDeclaration.builder()
                 .withIdentifier(builder.toString())
                 .withClassifier(M3Paths.QualifiedProperty)
-                .withLocation(toLocation(property.sourceInformation))
+                .withLocation(SourceInformationUtil.toLocation(property.sourceInformation))
                 .build();
     }
 

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
@@ -1,38 +1,47 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.mapping;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.block.factory.Functions;
 import org.eclipse.collections.impl.lazy.CompositeIterable;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLegacyParserLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult.Type;
+import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -43,9 +52,14 @@ import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMappingVisitor;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.OperationClassMapping;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.aggregationAware.AggregationAwareClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.MappingTestSuite;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.MappingTest_Legacy;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.modelToModel.mapping.PureInstanceClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.test.TestSuite;
 import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.test.runner.mapping.MappingTestRunner;
@@ -261,5 +275,50 @@ public class MappingLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
         }
 
         return CompositeIterable.with(legendCompletions, this.computeCompletionsForSupportedTypes(section, location, Set.of("Mapping")));
+    }
+
+    @Override
+    protected Collection<LegendReferenceResolver> getReferenceResolvers(SectionState section, PackageableElement packageableElement)
+    {
+        Mapping mapping = (Mapping) packageableElement;
+        return mapping.classMappings
+                .stream()
+                .flatMap(Functions.bind(this::toReferences, section.getDocumentState().getGlobalState()))
+                .collect(Collectors.toList());
+    }
+
+    private Stream<LegendReferenceResolver> toReferences(ClassMapping classMapping, GlobalState state)
+    {
+        LegendReferenceResolver legendReferenceResolver = LegendReferenceResolver.newReferenceResolver(classMapping.classSourceInformation, c -> c.resolveClass(classMapping._class, classMapping.classSourceInformation));
+
+        Stream<LegendReferenceResolver> otherReferences = classMapping.accept(new ClassMappingVisitor<>()
+        {
+            @Override
+            public Stream<LegendReferenceResolver> visit(ClassMapping classMapping)
+            {
+                return findExtensionThatImplements(state, MappingLSPGrammarProvider.class)
+                        .flatMap(x -> x.getClassMappingReferences(classMapping, state));
+            }
+
+            @Override
+            public Stream<LegendReferenceResolver> visit(OperationClassMapping operationClassMapping)
+            {
+                return Stream.empty();
+            }
+
+            @Override
+            public Stream<LegendReferenceResolver> visit(PureInstanceClassMapping pureInstanceClassMapping)
+            {
+                return Stream.empty();
+            }
+
+            @Override
+            public Stream<LegendReferenceResolver> visit(AggregationAwareClassMapping aggregationAwareClassMapping)
+            {
+                return Stream.empty();
+            }
+        });
+
+        return Stream.concat(Stream.of(legendReferenceResolver), otherReferences);
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarProvider.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarProvider.java
@@ -24,4 +24,5 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 public interface MappingLSPGrammarProvider
 {
     Stream<LegendReferenceResolver> getClassMappingReferences(ClassMapping mapping, GlobalState state);
+
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarProvider.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension.mapping;
+
+import java.util.stream.Stream;
+import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
+import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
+
+public interface MappingLSPGrammarProvider
+{
+    Stream<LegendReferenceResolver> getClassMappingReferences(ClassMapping mapping, GlobalState state);
+}

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
@@ -1,30 +1,43 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.relational;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
+import org.finos.legend.engine.ide.lsp.extension.AbstractSectionParserLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
+import org.finos.legend.engine.ide.lsp.extension.SourceInformationUtil;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.mapping.MappingLSPGrammarProvider;
+import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.grammar.from.RelationalGrammarParserExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.Column;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.ColumnMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.model.Database;
@@ -38,15 +51,10 @@ import org.finos.legend.pure.m2.relational.M2RelationalPaths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 /**
  * Extension for the Relational grammar.
  */
-public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGrammarExtension
+public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGrammarExtension implements MappingLSPGrammarProvider
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelationalLSPGrammarExtension.class);
 
@@ -59,10 +67,10 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
 
     private static final ImmutableList<String> SCHEMA_SUGGESTIONS = Lists.immutable.with(
             "schemaName\n" +
-                "(\n" +
-                " Table TableName1(column1 INT PRIMARY KEY, column2 DATE)\n" +
-                " Table TableName2(column3 VARCHAR(10) PRIMARY KEY)\n" +
-                ")\n"
+                    "(\n" +
+                    " Table TableName1(column1 INT PRIMARY KEY, column2 DATE)\n" +
+                    " Table TableName2(column3 VARCHAR(10) PRIMARY KEY)\n" +
+                    ")\n"
     );
 
     private static final ImmutableList<String> TABLE_TRIGGERS = Lists.immutable.with("Table ");
@@ -75,11 +83,11 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
 
     private static final ImmutableList<String> VIEW_SUGGESTIONS = Lists.immutable.with(
             "viewName\n" +
-                "(\n" +
-                "  field1: table1.column1, \n" +
-                "  field2: table2.column2,\n" +
-                "  field3: table1.column1 + table2.column2\n" +
-                ")\n"
+                    "(\n" +
+                    "  field1: table1.column1, \n" +
+                    "  field2: table2.column2,\n" +
+                    "  field3: table1.column1 + table2.column2\n" +
+                    ")\n"
     );
 
     private static final ImmutableList<String> JOIN_TRIGGERS = Lists.immutable.with("Join ");
@@ -96,13 +104,13 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
 
     private static final ImmutableList<String> BOILERPLATE_SUGGESTIONS = Lists.immutable.with(
             "Database package::path::storeName\n" +
-            "(\n" +
-            "  Schema schemaName\n" +
-            "  (\n" +
-            "   Table TableName1(column1 INT PRIMARY KEY, column2 DATE)\n" +
-            "   Table TableName2(column3 VARCHAR(10) PRIMARY KEY)\n" +
-            "  )\n" +
-            ")\n"
+                    "(\n" +
+                    "  Schema schemaName\n" +
+                    "  (\n" +
+                    "   Table TableName1(column1 INT PRIMARY KEY, column2 DATE)\n" +
+                    "   Table TableName2(column3 VARCHAR(10) PRIMARY KEY)\n" +
+                    "  )\n" +
+                    ")\n"
     );
 
     @Override
@@ -113,7 +121,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
 
         if (codeLine.isEmpty())
         {
-            return BOILERPLATE_SUGGESTIONS.collect(s -> new LegendCompletion("Relational boilerplate", s.replaceAll("\n",System.lineSeparator())));
+            return BOILERPLATE_SUGGESTIONS.collect(s -> new LegendCompletion("Relational boilerplate", s.replaceAll("\n", System.lineSeparator())));
         }
 
         if (SCHEMA_TRIGGERS.anySatisfy(codeLine::endsWith))
@@ -171,8 +179,8 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
     public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs)
     {
         return GENERATE_MODEL_MAPPING_COMMAND_ID.equals(commandId) ?
-               generateModelsFromDatabaseSpecification(section, entityPath) :
-               super.execute(section, entityPath, commandId, executableArgs);
+                generateModelsFromDatabaseSpecification(section, entityPath) :
+                super.execute(section, entityPath, commandId, executableArgs);
     }
 
     private Iterable<? extends LegendExecutionResult> generateModelsFromDatabaseSpecification(SectionState section, String entityPath)
@@ -233,7 +241,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
         LegendDeclaration.Builder builder = LegendDeclaration.builder()
                 .withIdentifier(schema.name)
                 .withClassifier(M2RelationalPaths.Schema)
-                .withLocation(toLocation(schema.sourceInformation));
+                .withLocation(SourceInformationUtil.toLocation(schema.sourceInformation));
         schema.tables.forEach(t -> addChildIfNonNull(builder, getDeclaration(t)));
         schema.views.forEach(v -> addChildIfNonNull(builder, getDeclaration(v)));
         return builder.build();
@@ -250,7 +258,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
         LegendDeclaration.Builder builder = LegendDeclaration.builder()
                 .withIdentifier(table.name)
                 .withClassifier(M2RelationalPaths.Table)
-                .withLocation(toLocation(table.sourceInformation));
+                .withLocation(SourceInformationUtil.toLocation(table.sourceInformation));
         table.columns.forEach(c -> addChildIfNonNull(builder, getDeclaration(c)));
         return builder.build();
     }
@@ -265,7 +273,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
         return LegendDeclaration.builder()
                 .withIdentifier(column.name)
                 .withClassifier(M2RelationalPaths.Column)
-                .withLocation(toLocation(column.sourceInformation))
+                .withLocation(SourceInformationUtil.toLocation(column.sourceInformation))
                 .build();
     }
 
@@ -280,7 +288,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
         LegendDeclaration.Builder builder = LegendDeclaration.builder()
                 .withIdentifier(view.name)
                 .withClassifier(M2RelationalPaths.Table)
-                .withLocation(toLocation(view.sourceInformation));
+                .withLocation(SourceInformationUtil.toLocation(view.sourceInformation));
         view.columnMappings.forEach(c -> addChildIfNonNull(builder, getDeclaration(c)));
         return builder.build();
     }
@@ -295,7 +303,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
         return LegendDeclaration.builder()
                 .withIdentifier(columnMapping.name)
                 .withClassifier("meta::relational::mapping::ColumnMapping")
-                .withLocation(toLocation(columnMapping.sourceInformation))
+                .withLocation(SourceInformationUtil.toLocation(columnMapping.sourceInformation))
                 .build();
     }
 
@@ -309,7 +317,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
         return LegendDeclaration.builder()
                 .withIdentifier(join.name)
                 .withClassifier(M2RelationalPaths.Join)
-                .withLocation(toLocation(join.sourceInformation))
+                .withLocation(SourceInformationUtil.toLocation(join.sourceInformation))
                 .build();
     }
 
@@ -323,7 +331,14 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
         return LegendDeclaration.builder()
                 .withIdentifier(filter.name)
                 .withClassifier(M2RelationalPaths.Filter)
-                .withLocation(toLocation(filter.sourceInformation))
+                .withLocation(SourceInformationUtil.toLocation(filter.sourceInformation))
                 .build();
+    }
+
+    @Override
+    public Stream<LegendReferenceResolver> getClassMappingReferences(ClassMapping mapping, GlobalState state)
+    {
+        // todo
+        return Stream.empty();
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/runtime/RuntimeLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/runtime/RuntimeLSPGrammarExtension.java
@@ -1,24 +1,27 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.runtime;
 
 import java.util.List;
 import java.util.Set;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.impl.lazy.CompositeIterable;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLegacyParserLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
@@ -1,18 +1,20 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.service;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.StreamReadFeature;
@@ -31,6 +33,7 @@ import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.lazy.CompositeIterable;
 import org.eclipse.collections.impl.utility.Iterate;
+import org.finos.legend.engine.ide.lsp.extension.AbstractSectionParserLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult.Type;

--- a/legend-engine-ide-lsp-default-extensions/src/main/resources/META-INF/services/org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension
+++ b/legend-engine-ide-lsp-default-extensions/src/main/resources/META-INF/services/org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension
@@ -1,6 +1,6 @@
-org.finos.legend.engine.ide.lsp.extension.ConnectionLSPGrammarExtension
-org.finos.legend.engine.ide.lsp.extension.MappingLSPGrammarExtension
-org.finos.legend.engine.ide.lsp.extension.PureLSPGrammarExtension
-org.finos.legend.engine.ide.lsp.extension.RelationalLSPGrammarExtension
-org.finos.legend.engine.ide.lsp.extension.RuntimeLSPGrammarExtension
-org.finos.legend.engine.ide.lsp.extension.ServiceLSPGrammarExtension
+org.finos.legend.engine.ide.lsp.extension.connection.ConnectionLSPGrammarExtension
+org.finos.legend.engine.ide.lsp.extension.mapping.MappingLSPGrammarExtension
+org.finos.legend.engine.ide.lsp.extension.core.PureLSPGrammarExtension
+org.finos.legend.engine.ide.lsp.extension.relational.RelationalLSPGrammarExtension
+org.finos.legend.engine.ide.lsp.extension.runtime.RuntimeLSPGrammarExtension
+org.finos.legend.engine.ide.lsp.extension.service.ServiceLSPGrammarExtension

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
@@ -37,7 +37,7 @@ import org.finos.legend.engine.ide.lsp.text.LineIndexedText;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-abstract class AbstractLSPGrammarExtensionTest<T extends LegendLSPGrammarExtension>
+public abstract class AbstractLSPGrammarExtensionTest<T extends LegendLSPGrammarExtension>
 {
     private static final Pattern GRAMMAR_LINE_PATTERN = Pattern.compile("^\\h*+###(?<parser>\\w++)\\h*+$\\R?", Pattern.MULTILINE);
     public static final String DOC_ID_FOR_TEXT = "file.pure";

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestDefaultLegendLSPExtensionLoader.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestDefaultLegendLSPExtensionLoader.java
@@ -20,6 +20,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import org.finos.legend.engine.ide.lsp.extension.connection.ConnectionLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.core.PureLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.mapping.MappingLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.relational.RelationalLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.runtime.RuntimeLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.service.ServiceLSPGrammarExtension;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/connection/TestConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/connection/TestConnectionLSPGrammarExtension.java
@@ -1,18 +1,20 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.connection;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpServer;
@@ -23,6 +25,8 @@ import org.apache.http.HttpStatus;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.utility.Iterate;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest;
+import org.finos.legend.engine.ide.lsp.extension.connection.ConnectionLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
@@ -32,7 +36,7 @@ import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.finos.legend.engine.ide.lsp.extension.ConnectionLSPGrammarExtension.GENERATE_DB_COMMAND_ID;
+import static org.finos.legend.engine.ide.lsp.extension.connection.ConnectionLSPGrammarExtension.GENERATE_DB_COMMAND_ID;
 
 
 public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensionTest<ConnectionLSPGrammarExtension>

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/connection/TestConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/connection/TestConnectionLSPGrammarExtension.java
@@ -26,7 +26,6 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest;
-import org.finos.legend.engine.ide.lsp.extension.connection.ConnectionLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
@@ -149,11 +148,5 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
             System.clearProperty("legend.engine.server.url");
             httpServer.stop(0);
         }
-    }
-
-    @Override
-    protected ConnectionLSPGrammarExtension newExtension()
-    {
-        return new ConnectionLSPGrammarExtension();
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/core/TestPureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/core/TestPureLSPGrammarExtension.java
@@ -239,10 +239,4 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
         String attributeMultiplicitiesSuggestion = this.extension.getCompletions(newSectionState("", code), TextPosition.newPosition(3, 15)).iterator().next().getDescription();
         Assertions.assertEquals("Attribute multiplicity", attributeMultiplicitiesSuggestion);
     }
-
-    @Override
-    protected PureLSPGrammarExtension newExtension()
-    {
-        return new PureLSPGrammarExtension();
-    }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/core/TestPureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/core/TestPureLSPGrammarExtension.java
@@ -1,28 +1,31 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.core;
 
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.MutableMap;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
-import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.pure.m3.navigation.M3Paths;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/mapping/TestMappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/mapping/TestMappingLSPGrammarExtension.java
@@ -26,6 +26,7 @@ import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
+import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.junit.jupiter.api.Assertions;
@@ -139,9 +140,67 @@ public class TestMappingLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         testDiagnostics(codeFiles, "vscodelsp::test::EmployeeMapping", LegendDiagnostic.newDiagnostic(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping", 3, 3, 3, 10), "Can't find class 'Employee'", Kind.Error, Source.Compiler));
     }
 
-    @Override
-    protected MappingLSPGrammarExtension newExtension()
+    @Test
+    public void testLegendReference()
     {
-        return new MappingLSPGrammarExtension();
+        MutableMap<String, String> codeFiles = Maps.mutable.empty();
+        codeFiles.put("vscodelsp::test::Employee",
+                "###Pure\n" +
+                "Class vscodelsp::test::Employee\n" +
+                "{\n" +
+                "    foobar: Float[1];\n" +
+                "    hireDate : Date[1];\n" +
+                "    hireType : String[1];\n" +
+                "}");
+
+        codeFiles.put("vscodelsp::test::EmployeeSrc",
+                "###Pure\n" +
+                        "Class vscodelsp::test::EmployeeSrc\n" +
+                        "{\n" +
+                        "    foobar: Float[1];\n" +
+                        "    hireDate : Date[1];\n" +
+                        "    hireType : String[1];\n" +
+                        "}");
+
+        codeFiles.put("vscodelsp::test::EmployeeMapping",
+                "###Mapping\n" +
+                "Mapping vscodelsp::test::EmployeeMapping\n" +
+                "(\n" +
+                "   vscodelsp::test::Employee[emp] : Pure\n" +
+                "   {\n" +
+                "      ~src vscodelsp::test::EmployeeSrc\n" +
+                "      hireDate : today(),\n" +
+                "      hireType : 'FullTime'\n" +
+                "   }\n" +
+                ")");
+
+        LegendReference targetMappedClassReference = LegendReference.builder()
+                .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",3,  3, 3, 27))
+                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::Employee", 1, 0, 6, 0))
+                .build();
+
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(2, 1), null, "Outside of targetMappedClassReference-able element should yield nothing");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(3, 2), null, "Outside of targetMappedClassReference-able element (before class name) should yield nothing");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(3, 3), targetMappedClassReference, "Start of class been mapped, references to class definition");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(3, 20), targetMappedClassReference, "Within the class name been mapped, references to class definition");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(3, 27), targetMappedClassReference, "End of class name been mapped, references to class definition");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(3, 28), null, "Outside of targetMappedClassReference-able element (after class name) should yield nothing");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(4, 1), null, "Outside of targetMappedClassReference-able element should yield nothing");
+
+        LegendReference srcMappedClassReference = LegendReference.builder()
+                .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",5,  11, 5, 38))
+                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeSrc", 1, 0, 6, 0))
+                .build();
+
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(5, 12), srcMappedClassReference, "Source class reference");
+
+        LegendReference propertyReference = LegendReference.builder()
+                .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",3,  3, 3, 27))
+                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::Employee", 1, 0, 6, 0))
+                .build();
+
+        // todo this would pass once engine is released with the change on MR https://github.com/finos/legend-engine/pull/2563
+        // testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(6, 10), propertyReference, "Property mapped reference");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(6, 10), null, "Property mapped reference");
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/mapping/TestMappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/mapping/TestMappingLSPGrammarExtension.java
@@ -1,30 +1,33 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.mapping;
 
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.set.MutableSet;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
-import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/relational/TestRelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/relational/TestRelationalLSPGrammarExtension.java
@@ -1,36 +1,39 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.relational;
 
 import java.util.Set;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.utility.Iterate;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
-import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.pure.m2.relational.M2RelationalPaths;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.finos.legend.engine.ide.lsp.extension.RelationalLSPGrammarExtension.GENERATE_MODEL_MAPPING_COMMAND_ID;
+import static org.finos.legend.engine.ide.lsp.extension.relational.RelationalLSPGrammarExtension.GENERATE_MODEL_MAPPING_COMMAND_ID;
 
 public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensionTest<RelationalLSPGrammarExtension>
 {

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/relational/TestRelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/relational/TestRelationalLSPGrammarExtension.java
@@ -27,6 +27,7 @@ import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.pure.m2.relational.M2RelationalPaths;
@@ -322,9 +323,61 @@ public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensi
         Assertions.assertEquals(Set.of("Database"), antlrExpectedTokens);
     }
 
-    @Override
-    protected RelationalLSPGrammarExtension newExtension()
+    @Test
+    public void testMappingLegendReference()
     {
-        return new RelationalLSPGrammarExtension();
+        MutableMap<String, String> codeFiles = Maps.mutable.empty();
+        codeFiles.put("vscodelsp::test::Employee",
+                "###Pure\n" +
+                        "Class vscodelsp::test::Employee\n" +
+                        "{\n" +
+                        "    foobar: Float[1];\n" +
+                        "    hireDate : Date[1];\n" +
+                        "    hireType : String[1];\n" +
+                        "}");
+
+        codeFiles.put("vscodelsp::test::EmployeeDatabase",
+                "###Relational\n" +
+                        "Database vscodelsp::test::EmployeeDatabase\n" +
+                        "(\n" +
+                        "   Table EmployeeTable(id INT PRIMARY KEY, hireDate DATE, hireType VARCHAR(10), fteFactor DOUBLE)\n" +
+                        "   Table EmployeeDetailsTable(id INT PRIMARY KEY, birthDate DATE, yearsOfExperience DOUBLE)\n" +
+                        "   Table FirmTable(firmName VARCHAR(100) PRIMARY KEY, employeeId INT PRIMARY KEY)\n" +
+                        "\n" +
+                        "   Join JoinEmployeeToFirm(EmployeeTable.id = FirmTable.employeeId)\n" +
+                        "   Join JoinEmployeeToemployeeDetails(EmployeeTable.id = EmployeeDetailsTable.id)\n" +
+                        "   Filter EmployeeFilter(EmployeeTable.hireType != sqlNull())\n" +
+                        ")");
+
+        codeFiles.put("vscodelsp::test::EmployeeMapping",
+                "###Mapping\n" +
+                        "Mapping vscodelsp::test::EmployeeMapping\n" +
+                        "(\n" +
+                        "   vscodelsp::test::Employee[emp] : Relational\n" +
+                        "   {\n" +
+                        "      ~mainTable [vscodelsp::test::EmployeeDatabase]EmployeeTable\n" +
+                        "      hireDate : [vscodelsp::test::EmployeeDatabase]EmployeeTable.hireDate,\n" +
+                        "      hireType : [vscodelsp::test::EmployeeDatabase]EmployeeTable.hireType\n" +
+                        "   }\n" +
+                        ")");
+
+
+        LegendReference mainTableReference = LegendReference.builder()
+                .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",5,  52, 5, 64))
+                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeDatabase", 3, 3, 3, 96))
+                .build();
+
+        // todo this would work once engine is released with the change on MR https://github.com/finos/legend-engine/pull/2563
+//        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(5, 60), mainTableReference, "main table reference");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(5, 60), null, "main table reference");
+
+        LegendReference columnReference = LegendReference.builder()
+                .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",6,   17, 6, 73))
+                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeDatabase", 3, 43, 3, 55))
+                .build();
+
+        // todo this would work once engine is released with the change on MR https://github.com/finos/legend-engine/pull/2563
+//        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(6, 21), columnReference, "Property mapped reference");
+        testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(6, 21), null, "Property mapped reference");
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/runtime/TestRuntimeLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/runtime/TestRuntimeLSPGrammarExtension.java
@@ -1,22 +1,26 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.runtime;
 
+import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
+import org.finos.legend.engine.ide.lsp.extension.runtime.RuntimeLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.junit.jupiter.api.Assertions;

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/runtime/TestRuntimeLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/runtime/TestRuntimeLSPGrammarExtension.java
@@ -20,9 +20,8 @@ import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
-import org.finos.legend.engine.ide.lsp.extension.runtime.RuntimeLSPGrammarExtension;
-import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -91,11 +90,5 @@ public class TestRuntimeLSPGrammarExtension extends AbstractLSPGrammarExtensionT
 
         String boilerPlate = this.extension.getCompletions(newSectionState("", code), TextPosition.newPosition(2, 0)).iterator().next().getDescription();
         Assertions.assertEquals("Runtime boilerplate", boilerPlate);
-    }
-
-    @Override
-    protected RuntimeLSPGrammarExtension newExtension()
-    {
-        return new RuntimeLSPGrammarExtension();
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
@@ -1,25 +1,29 @@
-// Copyright 2023 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.service;
 
 import java.util.Set;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
+import org.finos.legend.engine.ide.lsp.extension.service.ServiceLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.junit.jupiter.api.Assertions;

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
@@ -23,9 +23,8 @@ import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
-import org.finos.legend.engine.ide.lsp.extension.service.ServiceLSPGrammarExtension;
-import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -138,11 +137,5 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
     {
         Set<String> antlrExpectedTokens = this.extension.getAntlrExpectedTokens();
         Assertions.assertEquals(Set.of("Service", "ExecutionEnvironment"), antlrExpectedTokens);
-    }
-
-    @Override
-    protected ServiceLSPGrammarExtension newExtension()
-    {
-        return new ServiceLSPGrammarExtension();
     }
 }


### PR DESCRIPTION
This introduce the extension API to support references and navigation to go to definition from references.

It leverage the protocol classes to figure out the pointer locations, and then leverage the compile graph to resolve the referenced element (and implicitly the location of such element)

This does NOT introduce much implementation other than a simple class reference on the mapping DSL.  It does introduce the dispatching to other grammar extensions, like mapping  to relational.

I will introduce the relational implementation on a subsequent PR.

This also move the extensions to sub-packages, with the goal to keep DSL specific classes within the same package, and will allow us for better extract this code and move it to legend-engine.
     