### PR TITLE
Bug fixes on REPL and on diagnostic pull model  

### DIFF
--- a/.github/workflows/test-result.yml
+++ b/.github/workflows/test-result.yml
@@ -52,6 +52,6 @@ jobs:
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           check_name: Test Results
-          event_file: artifacts/event-file/event.json
+          event_file: artifacts/event-file-ubuntu-latest/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: "artifacts/**/*.xml"

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
@@ -230,7 +230,7 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
                 .thenAccept(this.extensionGuard::initialize)
                 .thenRun(this.extensionGuard.wrapOnClasspath(this::reprocessDocuments))
                 // trigger compilation
-                .thenRun(this.extensionGuard.wrapOnClasspath(() -> this.globalState.forEachDocumentState(this.textDocumentService::publishDiagnosticsToClient)))
+                .thenRun(this.extensionGuard.wrapOnClasspath(() -> this.globalState.forEachDocumentState(this.textDocumentService::getLegendDiagnostics)))
                 .thenRun(() ->
                 {
                     LanguageClient languageClient = this.getLanguageClient();
@@ -790,10 +790,19 @@ public class LegendLanguageServer implements LanguageServer, LanguageClientAware
         capabilities.setCodeLensProvider(getCodeLensOptions());
         capabilities.setExecuteCommandProvider(getExecuteCommandOptions());
         capabilities.setDefinitionProvider(true);
-        capabilities.setDiagnosticProvider(new DiagnosticRegistrationOptions(true, true));
+        capabilities.setDiagnosticProvider(getDiagnosticRegistrationOptions());
         capabilities.setDocumentSymbolProvider(true);
         capabilities.setWorkspaceSymbolProvider(true);
         return capabilities;
+    }
+
+    private DiagnosticRegistrationOptions getDiagnosticRegistrationOptions()
+    {
+        DiagnosticRegistrationOptions diagnosticProvider = new DiagnosticRegistrationOptions();
+        diagnosticProvider.setId("legend_diagnostic");
+        diagnosticProvider.setWorkspaceDiagnostics(true);
+        diagnosticProvider.setInterFileDependencies(true);
+        return diagnosticProvider;
     }
 
     private WorkspaceServerCapabilities getWorkspaceServerCapabilities()

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendREPLTerminal.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendREPLTerminal.java
@@ -38,8 +38,9 @@ public class LegendREPLTerminal
         try
         {
             ClasspathUsingMavenFactory factory = new ClasspathUsingMavenFactory(new File(pomPath));
+            File maven = factory.getMavenExecLocation(mavenPath);
             URLClassLoader classloader = Objects.requireNonNull(
-                    factory.createClassloader(mavenPath.isBlank() ? null : new File(mavenPath), new File(pomPath)),
+                    factory.createClassloader(maven, new File(pomPath)),
                     "Failed to load classpath from pom");
 
             Thread.currentThread().setContextClassLoader(classloader);

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
@@ -367,14 +367,10 @@ class LegendWorkspaceService implements WorkspaceService
 
             this.server.getGlobalState().forEachDocumentState(d ->
             {
-                // todo handle previous result so we send WorkspaceUnchangedDocumentDiagnosticReport if nothing changed?
                 LegendServerGlobalState.LegendServerDocumentState doc = (LegendServerGlobalState.LegendServerDocumentState) d;
                 List<LegendDiagnostic> diagnostics = this.server.getTextDocumentService().getLegendDiagnostics(doc);
-                if (!diagnostics.isEmpty())
-                {
-                    WorkspaceFullDocumentDiagnosticReport fullReport = new WorkspaceFullDocumentDiagnosticReport(diagnostics.stream().map(LegendToLSPUtilities::toDiagnostic).collect(Collectors.toList()), doc.getDocumentId(), doc.getVersion());
-                    items.add(new WorkspaceDocumentDiagnosticReport(fullReport));
-                }
+                WorkspaceFullDocumentDiagnosticReport fullReport = new WorkspaceFullDocumentDiagnosticReport(diagnostics.stream().map(LegendToLSPUtilities::toDiagnostic).collect(Collectors.toList()), doc.getDocumentId(), doc.getVersion());
+                items.add(new WorkspaceDocumentDiagnosticReport(fullReport));
             });
 
             return new WorkspaceDiagnosticReport(items);


### PR DESCRIPTION
This fixes a few small bugs:

1. REPL should introspect system path for maven executable when one is not provided
2. Workspace diagnostics should always publish, even if document has no diagnostics.  This is to ensure the client can clear old diagnostics 
3. We should not publish diagnostics as now we move to pull model.  This is to avoid duplicated diagnostics presented to users
4. With the build running on multiple OSs, the artifact file for publishing test cases need to match the new name 