### PR TITLE
REPL fixes to improve integration

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/pom.xml
+++ b/legend-engine-ide-lsp-default-extensions/pom.xml
@@ -35,6 +35,16 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- to prevent failures on REPL test cases... we need better mechanism to manage H2 port...-->
+                        <legend.test.h2.port>1975</legend.test.h2.port>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -51,6 +61,24 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <scope>test</scope>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <scope>test</scope>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <scope>test</scope>
+                <version>${junit.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -175,6 +203,21 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-executionPlan-connection</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-executionPlan-generation</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -216,6 +259,12 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-repl-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-repl-relational</artifactId>
+            <version>${legend.engine.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -295,6 +344,18 @@
 
         <!-- TEST -->
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine.ide.lsp</groupId>
             <artifactId>legend-engine-ide-lsp-text-tools</artifactId>
             <scope>test</scope>
@@ -307,6 +368,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- TEST -->

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/LegendTDSRequestHandlerImpl.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/LegendTDSRequestHandlerImpl.java
@@ -24,7 +24,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtension;
-import org.finos.legend.engine.ide.lsp.extension.LegendTDSRequestHandler;
+import org.finos.legend.engine.ide.lsp.extension.features.LegendTDSRequestHandler;
 import org.finos.legend.engine.ide.lsp.extension.LegendTDSRequestLambdaBuilder;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.ColumnType;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.Filter;

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/repl/LegendREPLFeatureImpl.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/repl/LegendREPLFeatureImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension.repl;
+
+import org.finos.legend.engine.ide.lsp.extension.features.LegendREPLFeature;
+import org.finos.legend.engine.plan.execution.stores.relational.AlloyH2Server;
+import org.finos.legend.engine.repl.relational.client.RClient;
+import org.h2.tools.Server;
+
+public class LegendREPLFeatureImpl implements LegendREPLFeature
+{
+    @Override
+    public String description()
+    {
+        return "Legend REPL";
+    }
+
+    @Override
+    public void startREPL()
+    {
+        Server server = null;
+        try
+        {
+            server = AlloyH2Server.startServer(1975);
+            RClient.main(new String[0]);
+        }
+        catch (Exception e)
+        {
+            throw new RuntimeException(e);
+        }
+        finally
+        {
+            if (server != null)
+            {
+                server.stop();
+            }
+        }
+    }
+}

--- a/legend-engine-ide-lsp-default-extensions/src/main/resources/META-INF/services/org.finos.legend.engine.ide.lsp.extension.LegendLSPFeature
+++ b/legend-engine-ide-lsp-default-extensions/src/main/resources/META-INF/services/org.finos.legend.engine.ide.lsp.extension.LegendLSPFeature
@@ -16,3 +16,4 @@
 
 org.finos.legend.engine.ide.lsp.extension.sdlc.LegendDependencyManagementImpl
 org.finos.legend.engine.ide.lsp.extension.core.LegendTDSRequestHandlerImpl
+org.finos.legend.engine.ide.lsp.extension.repl.LegendREPLFeatureImpl

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestDefaultExtensions.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestDefaultExtensions.java
@@ -39,7 +39,7 @@ public class TestDefaultExtensions
     {
         MutableList<LegendLSPFeature> extensions = Lists.mutable.withAll(ServiceLoader.load(LegendLSPFeature.class));
         Assertions.assertEquals(
-                Sets.mutable.with("Handles Legend SDLC features", "Legend TDS Request Handler"),
+                Sets.mutable.with("Handles Legend SDLC features", "Legend TDS Request Handler", "Legend REPL"),
                 extensions.collect(LegendLSPFeature::description, Sets.mutable.empty())
         );
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/repl/LegendREPLFeatureTest.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/repl/LegendREPLFeatureTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension.repl;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.jline.terminal.TerminalBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@Timeout(value = 3, unit = TimeUnit.MINUTES)
+public class LegendREPLFeatureTest
+{
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    @AfterEach
+    void tearDown()
+    {
+        this.executorService.shutdownNow();
+    }
+
+    @Test
+    void replStarts() throws Exception
+    {
+        PipedInputStream replInput = new PipedInputStream();
+        OutputStreamWriter replInputConsole = new OutputStreamWriter(new PipedOutputStream(replInput));
+
+        PipedOutputStream replOutput = new PipedOutputStream();
+        PipedInputStream replOutputConsole = new PipedInputStream(replOutput);
+
+        TerminalBuilder.setTerminalOverride(TerminalBuilder.builder().streams(replInput, replOutput).build());
+
+        Future<?> replFuture = this.executorService.submit(new LegendREPLFeatureImpl()::startREPL);
+
+        read(replFuture, replOutputConsole, "Ready!");
+
+        sendREPLCommand(replInputConsole, "help");
+        read(replFuture, replOutputConsole, "<pure expression>");
+
+        sendREPLCommand(replInputConsole, "exit");
+        // wait for repl to complete and exit
+        replFuture.get(30, TimeUnit.SECONDS);
+    }
+
+    private static void sendREPLCommand(OutputStreamWriter replInputConsole, String help) throws IOException
+    {
+        replInputConsole.write(help + System.lineSeparator());
+        replInputConsole.flush();
+    }
+
+    private static void read(Future<?> replFuture, PipedInputStream replOutputConsole, String untilToken) throws Exception
+    {
+        StringBuilder output = new StringBuilder();
+
+        while (true)
+        {
+            if (replFuture.isDone())
+            {
+                // will throw if an exception happen
+                replFuture.get();
+                break;
+            }
+
+            int read = replOutputConsole.read();
+            if (read != -1)
+            {
+                System.err.print((char) read);
+                output.append((char) read);
+            }
+            else
+            {
+                break;
+            }
+
+            if (output.toString().contains(untilToken))
+            {
+                break;
+            }
+        }
+    }
+}

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendREPLFeature.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendREPLFeature.java
@@ -14,26 +14,11 @@
  * limitations under the License.
  */
 
-package org.finos.legend.engine.ide.lsp.server;
+package org.finos.legend.engine.ide.lsp.extension.features;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import org.finos.legend.engine.ide.lsp.extension.features.LegendUsageEventConsumer;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPFeature;
 
-public class InMemoryEventConsumer implements LegendUsageEventConsumer
+public interface LegendREPLFeature extends LegendLSPFeature
 {
-    public final List<LegendUsageEvent> events = Collections.synchronizedList(new ArrayList<>());
-
-    @Override
-    public String description()
-    {
-        return "in memory consumer";
-    }
-
-    @Override
-    public void consume(LegendUsageEvent event)
-    {
-        this.events.add(event);
-    }
+    void startREPL();
 }

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendTDSRequestHandler.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendTDSRequestHandler.java
@@ -1,20 +1,23 @@
-// Copyright 2024 Goldman Sachs
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.features;
 
 import java.util.Map;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPFeature;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.TDSRequest;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendUsageEventConsumer.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendUsageEventConsumer.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package org.finos.legend.engine.ide.lsp.extension;
+package org.finos.legend.engine.ide.lsp.extension.features;
 
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPFeature;
 
 /**
  * Defines the contract for event consumption, allowing custom event tracking that fit different environments

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
@@ -79,7 +79,7 @@ import org.finos.legend.engine.ide.lsp.classpath.EmbeddedClasspathFactory;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPFeature;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarLibrary;
-import org.finos.legend.engine.ide.lsp.extension.LegendUsageEventConsumer;
+import org.finos.legend.engine.ide.lsp.extension.features.LegendUsageEventConsumer;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.server.service.LegendLanguageServiceContract;
 import org.slf4j.Logger;

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageService.java
@@ -18,9 +18,14 @@ package org.finos.legend.engine.ide.lsp.server;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.io.File;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
-import org.finos.legend.engine.ide.lsp.extension.LegendTDSRequestHandler;
+import java.util.stream.Collectors;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.features.LegendTDSRequestHandler;
 import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.server.service.FunctionTDSRequest;
@@ -68,5 +73,38 @@ public class LegendLanguageService implements LegendLanguageServiceContract
             this.server.logInfoToClient(result.getMessage());
             return result;
         }).whenComplete((r, t) -> this.server.fireEvent("TDSRequest", start, Collections.emptyMap(), t));
+    }
+
+    @Override
+    public CompletableFuture<String> replClasspath()
+    {
+        return this.server.supplyPossiblyAsync(() ->
+        {
+            String classpath = System.getProperty("java.class.path");
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            if (contextClassLoader instanceof URLClassLoader)
+            {
+                URLClassLoader urlClassLoader = (URLClassLoader) contextClassLoader;
+
+                if ("legend-lsp".equals(urlClassLoader.getName()))
+                {
+                    classpath = classpath + File.pathSeparator + Arrays.stream(urlClassLoader.getURLs())
+                            .map(x ->
+                            {
+                                try
+                                {
+                                    return Path.of(x.toURI()).toAbsolutePath().toString();
+                                }
+                                catch (Exception e)
+                                {
+                                    throw new RuntimeException(e);
+                                }
+                            })
+                            .collect(Collectors.joining(File.pathSeparator));
+                }
+            }
+
+            return classpath;
+        });
     }
 }

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/service/LegendLanguageServiceContract.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/service/LegendLanguageServiceContract.java
@@ -26,4 +26,7 @@ public interface LegendLanguageServiceContract
 {
     @JsonRequest("TDSRequest")
     CompletableFuture<LegendExecutionResult> legendTDSRequest(FunctionTDSRequest rq);
+
+    @JsonRequest("replClasspath")
+    CompletableFuture<String> replClasspath();
 }

--- a/legend-engine-ide-lsp-server/src/test/resources/integrationTestPom.xml
+++ b/legend-engine-ide-lsp-server/src/test/resources/integrationTestPom.xml
@@ -106,6 +106,12 @@
             <version>${legend.engine.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-repl-relational</artifactId>
+            <version>${legend.engine.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>


### PR DESCRIPTION
This PR improve the REPL integration, and add proper unit test to ensure it integrates as expected.

To minimize the REPL terminal complexity, Im adding a RPC method on the language server to get a classpath, so that the server resolves this, and avoid trying to resolve it on the REPL main, as the REPL does not have access to the full state of the worksapce.