### PR TITLE
Improve performance of workspace diagnostics

### DIFF
--- a/legend-engine-ide-lsp-default-extensions-dependencies/pom.xml
+++ b/legend-engine-ide-lsp-default-extensions-dependencies/pom.xml
@@ -15,16 +15,30 @@
   ~ limitations under the License.
   -->
 
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.finos.legend.engine.ide.lsp</groupId>
+        <artifactId>legend-engine-ide-lsp</artifactId>
+        <version>0.0.11-SNAPSHOT</version>
+    </parent>
 
-    <groupId>org.finos.legend.ide.lsp</groupId>
-    <artifactId>default-pom</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <artifactId>legend-engine-ide-lsp-default-extensions-dependencies</artifactId>
+    <packaging>pom</packaging>
 
-    <name>Default provided dependencies for the LSP Server</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
 
@@ -32,8 +46,6 @@
             <groupId>org.finos.legend.engine.ide.lsp</groupId>
             <artifactId>legend-engine-ide-lsp-default-extensions</artifactId>
             <version>${project.version}</version>
-            <scope>system</scope>
-            <systemPath>${project.parent.basedir}/legend-engine-ide-lsp-default-extensions/target/legend-engine-ide-lsp-default-extensions-${project.version}.jar</systemPath>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -113,5 +125,6 @@
         </dependency>
 
     </dependencies>
+
 
 </project>

--- a/legend-engine-ide-lsp-server/pom.xml
+++ b/legend-engine-ide-lsp-server/pom.xml
@@ -52,6 +52,31 @@
                     </rules>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-default-pom</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/generated-test-resources</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${project.parent.basedir}/legend-engine-ide-lsp-default-extensions-dependencies</directory>
+                                    <includes>
+                                        <include>pom.xml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <resources>
@@ -64,6 +89,10 @@
         <testResources>
             <testResource>
                 <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+            <testResource>
+                <directory>target/generated-test-resources</directory>
                 <filtering>true</filtering>
             </testResource>
         </testResources>

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
@@ -859,7 +859,8 @@ public class LegendLanguageServer implements LegendLanguageServerContract
     private DiagnosticRegistrationOptions getDiagnosticRegistrationOptions()
     {
         DiagnosticRegistrationOptions diagnosticProvider = new DiagnosticRegistrationOptions();
-        diagnosticProvider.setId("legend_diagnostic");
+        diagnosticProvider.setId("Legend");
+        diagnosticProvider.setIdentifier("Legend");
         diagnosticProvider.setWorkspaceDiagnostics(true);
         diagnosticProvider.setInterFileDependencies(true);
         return diagnosticProvider;

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.ide.lsp.server;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -143,6 +144,8 @@ public class LegendTextDocumentService implements TextDocumentService
             {
                 globalState.clearProperties();
                 this.server.getLanguageClient().refreshDiagnostics();
+                this.server.getLanguageClient().refreshSemanticTokens();
+                this.server.getLanguageClient().refreshCodeLenses();
             }
 
             LOGGER.debug("Changed {} (version {})", uri, doc.getVersion());
@@ -355,9 +358,9 @@ public class LegendTextDocumentService implements TextDocumentService
         return diagnostics;
     }
 
-    protected List<LegendDiagnostic> getLegendDiagnostics(DocumentState docState)
+    protected Set<LegendDiagnostic> getLegendDiagnostics(DocumentState docState)
     {
-        List<LegendDiagnostic> diagnostics = new ArrayList<>();
+        Set<LegendDiagnostic> diagnostics = new HashSet<>();
         docState.forEachSectionState(sectionState ->
         {
             LegendLSPGrammarExtension extension = sectionState.getExtension();

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/LegendLanguageServerIntegrationExtension.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/LegendLanguageServerIntegrationExtension.java
@@ -140,7 +140,7 @@ public class LegendLanguageServerIntegrationExtension implements
         LSPMessageTrackerFactory lspMessageTrackerFactory = new LSPMessageTrackerFactory(phaser);
 
         Path pomPath = this.workspaceFolderPath.resolve("pom.xml");
-        try (InputStream pom = TestLegendLanguageServerIntegration.class.getClassLoader().getResourceAsStream("integrationTestPom.xml"))
+        try (InputStream pom = TestLegendLanguageServerIntegration.class.getClassLoader().getResourceAsStream("pom.xml"))
         {
             Files.copy(Objects.requireNonNull(pom, "missing integration test pom"), pomPath);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <module>legend-engine-ide-lsp-text-tools</module>
         <module>legend-engine-ide-lsp-extension-api</module>
         <module>legend-engine-ide-lsp-default-extensions</module>
+        <module>legend-engine-ide-lsp-default-extensions-dependencies</module>
         <!--
             this module needs to be after the default-extension, as it is used for integration testing, implicitly.
             This is not ideal dependency, and we will explore other options to see how we can have the extensions


### PR DESCRIPTION
The workspace diagnostics on VS Code run every 2 seconds, regardless if something changes in the workspace.

That meant, that the way we reported was clogging VS Code, and creating slowness on other places.  On the **_Extension Host_** logs, this was appearing for every file, every 2 seconds:

> 2024-03-23 14:37:00.875 [trace] [DiagnosticCollection] change many (extension, owner, uris) FINOS.legend-engine-ide-client-vscode Legend [[{"$mid":1,"fsPath":"c:\\Users\\cocob\\vsCodeProjects\\legend-showcase-relational-mapping\\relational-mapping-entities\\src\\main\\pure\\relationalMapping\\ProductClassification.pure","_sep":1,"external":"file:///c%3A/Users/cocob/vsCodeProjects/legend-showcase-relational-mapping/relational-mapping-entities/src/main/pure/relationalMapping/ProductClassification.pure","path":"/c:/Users/cocob/vsCodeProjects/legend-showcase-relational-mapping/relational-mapping-entities/src/main/pure/relationalMapping/ProductClassification.pure","scheme":"file"},[]]]

This implementation leverage the previous result id to just publish for documents that actually have changes on their diagnostics that need to be published, reducing the state changes VS Code needs to manage.

While more testing is required, this already shows better responsiveness on VS Code.

This also introduce a new POM only module to manage the extension dependencies.  This new pom will be used on VS Code extension, avoiding managing duplicated poms between integration test and vs code.  