### PR TITLE
Improve classpath discovery performance by reducing maven invocations

### DIFF
--- a/legend-engine-ide-lsp-server/pom.xml
+++ b/legend-engine-ide-lsp-server/pom.xml
@@ -182,6 +182,11 @@
             <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>

--- a/legend-engine-ide-lsp-server/pom.xml
+++ b/legend-engine-ide-lsp-server/pom.xml
@@ -132,12 +132,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-            <version>3.5.1</version>
-        </dependency>
-        
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>

--- a/legend-engine-ide-lsp-server/pom.xml
+++ b/legend-engine-ide-lsp-server/pom.xml
@@ -130,6 +130,12 @@
             <artifactId>maven-model</artifactId>
             <version>3.9.6</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>3.5.1</version>
+        </dependency>
         
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
@@ -420,7 +420,7 @@ public class ClasspathUsingMavenFactory implements ClasspathFactory
         return dependencies;
     }
 
-    private URLClassLoader createClassloader(File maven, File pom, File settingXml, List<String> extraDependencies, List<SDLCPlatform> platformVersions) throws Exception
+    private URLClassLoader createClassloader(File maven, File pom, File settingXml, List<String> extraDependencies, List<SDLCPlatform> platformVersions)
     {
         CompletableFuture<Stream<URL>> coreClasspathFuture = this.server.supplyPossiblyAsync(() -> this.getClasspathURLEntries("core", maven, pom, settingXml));
         CompletableFuture<Stream<URL>> extraClasspathFuture = this.server.supplyPossiblyAsync(() ->
@@ -573,12 +573,27 @@ public class ClasspathUsingMavenFactory implements ClasspathFactory
 
     private Stream<URL> getClasspathURLEntries(String id, File maven, File pom, File settingXml)
     {
-        File cacheDir = new File(System.getProperty("storagePath", System.getProperty("java.io.tmpdir")));
-        File legendLspClasspath = new File(cacheDir, "legend_lsp_classpath_" + id + ".txt");
-        File legendLspCachedPom = new File(cacheDir, "pom_" + id + ".xml");
-
         try
         {
+            String storageDir = System.getProperty("storagePath");
+            File legendLspClasspath;
+            File legendLspCachedPom;
+
+            if (storageDir == null)
+            {
+                legendLspClasspath = File.createTempFile("legend_lsp_classpath_", id + ".txt");
+                legendLspClasspath.deleteOnExit();
+
+                legendLspCachedPom = File.createTempFile("pom_", id + ".xml");
+                legendLspCachedPom.deleteOnExit();
+            }
+            else
+            {
+                File cacheDir = new File(storageDir);
+                legendLspClasspath = new File(cacheDir, "legend_lsp_classpath_" + id + ".txt");
+                legendLspCachedPom = new File(cacheDir, "pom_" + id + ".xml");
+            }
+
             boolean reloadClasspath = true;
 
             String[] classpath = null;

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/LegendLanguageServerIntegrationExtension.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/LegendLanguageServerIntegrationExtension.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.io.FileUtils;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.DeleteFilesParams;
 import org.eclipse.lsp4j.Diagnostic;
@@ -90,6 +91,7 @@ public class LegendLanguageServerIntegrationExtension implements
     @Override
     public void afterAll(ExtensionContext context) throws Exception
     {
+        FileUtils.deleteDirectory(workspaceFolderPath.toFile());
         clientFuture.cancel(true);
         serverFuture.cancel(true);
         executorService.shutdown();
@@ -193,6 +195,11 @@ public class LegendLanguageServerIntegrationExtension implements
             // catch to add phaser state, and rethrow TimeoutException to allow test watcher to print thread dump...
             throw new TimeoutException("Not all parties arrived to phaser? " + phaser);
         }
+    }
+
+    public boolean clientLogged(String logMsg)
+    {
+        return this.client.clientLog.contains(logMsg);
     }
 
     public Path addToWorkspace(String relativePath, String content) throws Exception

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerIntegration.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerIntegration.java
@@ -18,9 +18,6 @@ package org.finos.legend.engine.ide.lsp.server.integration;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -46,10 +43,10 @@ import org.eclipse.lsp4j.WorkspaceDiagnosticParams;
 import org.eclipse.lsp4j.WorkspaceDocumentDiagnosticReport;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.finos.legend.engine.ide.lsp.utils.LegendToLSPUtilities;
-import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
@@ -343,53 +340,6 @@ public class TestLegendLanguageServerIntegration
                 .stream()
                 .map(x -> new PreviousResultId(x.getWorkspaceFullDocumentDiagnosticReport().getUri(), x.getWorkspaceFullDocumentDiagnosticReport().getResultId()))
                 .collect(Collectors.toList());
-    }
-
-    @Test
-    void testReplStartWithGivenClasspath() throws Exception
-    {
-        String classpath = extension.futureGet(extension.getServer().getLegendLanguageService().replClasspath());
-
-        ProcessBuilder processBuilder = new ProcessBuilder(
-                System.getProperty("java.home") + File.separator + "bin" + File.separator + "java",
-                "org.finos.legend.engine.ide.lsp.server.LegendREPLTerminal"
-        );
-        processBuilder.environment().put("CLASSPATH", classpath);
-        processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
-        Process process = null;
-        try
-        {
-            process = processBuilder.start();
-            Assertions.assertTrue(process.isAlive());
-            read(process.getInputStream(), "Ready!");
-        }
-        finally
-        {
-            if (process != null)
-            {
-                process.destroy();
-                process.onExit().join();
-            }
-        }
-    }
-
-    private static void read(InputStream replOutputConsole, String untilToken) throws IOException
-    {
-        StringBuilder output = new StringBuilder();
-        while (!output.toString().contains(untilToken))
-        {
-            int read = replOutputConsole.read();
-            if (read != -1)
-            {
-                System.err.print((char) read);
-                output.append((char) read);
-            }
-            else
-            {
-                Assertions.fail("Did not found token and stream closed...");
-            }
-
-        }
     }
 
     @Test

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerMavenIntegration.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerMavenIntegration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.server.integration;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.lsp4j.InitializedParams;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Timeout(value = 3, unit = TimeUnit.MINUTES)
+// all tests should finish but in case of some uncaught deadlock, timeout whole test
+public class TestLegendLanguageServerMavenIntegration
+{
+    @RegisterExtension
+    static LegendLanguageServerIntegrationExtension extension = new LegendLanguageServerIntegrationExtension();
+
+    @Test
+    void testMavenClasspathCache() throws Exception
+    {
+        Path workspaceStoragePath = Files.createTempDirectory("legend-integration-storage");
+
+        try
+        {
+            System.setProperty("storagePath", workspaceStoragePath.toString());
+
+            // load, will create cache files
+            extension.getServer().initialized(new InitializedParams());
+            extension.waitForAllTaskToComplete();
+
+            extension.getServer().initialized(new InitializedParams());
+            extension.waitForAllTaskToComplete();
+
+            Assertions.assertTrue(extension.clientLogged("logMessage - Info - Reusing cached core classpath rather that invoking maven"), "Core classpath should be reused");
+        }
+        catch (Exception e)
+        {
+            System.clearProperty("storagePath");
+            FileUtils.deleteDirectory(workspaceStoragePath.toFile());
+            throw e;
+        }
+    }
+}

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerReplIntegration.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerReplIntegration.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.server.integration;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@Timeout(value = 3, unit = TimeUnit.MINUTES)
+// all tests should finish but in case of some uncaught deadlock, timeout whole test
+public class TestLegendLanguageServerReplIntegration
+{
+    @RegisterExtension
+    static LegendLanguageServerIntegrationExtension extension = new LegendLanguageServerIntegrationExtension();
+
+    @Test
+    void testReplStartWithGivenClasspath() throws Exception
+    {
+        String classpath = extension.futureGet(extension.getServer().getLegendLanguageService().replClasspath());
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                System.getProperty("java.home") + File.separator + "bin" + File.separator + "java",
+                "org.finos.legend.engine.ide.lsp.server.LegendREPLTerminal"
+        );
+        processBuilder.environment().put("CLASSPATH", classpath);
+        processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+        Process process = null;
+        try
+        {
+            process = processBuilder.start();
+            Assertions.assertTrue(process.isAlive());
+            read(process.getInputStream(), "Ready!");
+        }
+        finally
+        {
+            if (process != null)
+            {
+                process.destroy();
+                process.onExit().join();
+            }
+        }
+    }
+
+    private static void read(InputStream replOutputConsole, String untilToken) throws IOException
+    {
+        StringBuilder output = new StringBuilder();
+        while (!output.toString().contains(untilToken))
+        {
+            int read = replOutputConsole.read();
+            if (read != -1)
+            {
+                System.err.print((char) read);
+                output.append((char) read);
+            }
+            else
+            {
+                Assertions.fail("Did not found token and stream closed...");
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
This PR changes/introduce the following:

- Apply platform versions directly by reading/writing the POM file, avoiding calling maven per each platform entry
- If SDLC platforms contains legend-engine, use this version rather than invoking maven to find such version
- Cache in the "workspace storage" the used pom and resulted classpath, so that we can try to reused the next time the workspace is open.  Classpath is only reused if entries still exists, and if no -SNAPSHOT is used.
