### PR TITLE
Bugfix on how dependencies are processed (parsed/compiled)

### DIFF
--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
@@ -293,7 +293,7 @@ public class LegendLanguageServer implements LegendLanguageServerContract
         return this.classpathFactory.create(Collections.unmodifiableSet(this.rootFolders))
                 .thenAccept(this.extensionGuard::initialize)
                 .thenRun(this.extensionGuard.wrapOnClasspath(this::reprocessDocuments))
-                .thenRun(this.legendLanguageService::loadVirtualFileSystemContent)
+                .thenRun(this.extensionGuard.wrapOnClasspath(this.legendLanguageService::loadVirtualFileSystemContent))
                 // trigger compilation
                 .thenRun(this.extensionGuard.wrapOnClasspath(() -> this.globalState.forEachDocumentState(this.textDocumentService::getLegendDiagnostics)))
                 .thenRun(() ->

--- a/legend-engine-ide-lsp-server/src/test/resources/entities/vscodelsp/test/dependency/StaticConnection.json
+++ b/legend-engine-ide-lsp-server/src/test/resources/entities/vscodelsp/test/dependency/StaticConnection.json
@@ -1,0 +1,24 @@
+{
+  "classifierPath": "meta::external::store::relational::runtime::RelationalDatabaseConnection",
+  "content": {
+    "_type": "connection",
+    "name": "StaticConnection",
+    "connectionValue": {
+      "_type": "RelationalDatabaseConnection",
+      "type": "H2",
+      "timeZone": null,
+      "quoteIdentifiers": null,
+      "postProcessorWithParameter": [],
+      "datasourceSpecification": {
+        "_type": "h2Local"
+      },
+      "authenticationStrategy": {
+        "_type": "h2Default"
+      },
+      "databaseType": "H2",
+      "postProcessors": null,
+      "localMode": null
+    },
+    "package": "vscodelsp::test::dependency"
+  }
+}


### PR DESCRIPTION
The processing needs to be wrapped on the dynamic classpath we construct.  