### PR TITLE
Support executing services lambdas

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/pom.xml
+++ b/legend-engine-ide-lsp-default-extensions/pom.xml
@@ -35,16 +35,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <!-- to prevent failures on REPL test cases... we need better mechanism to manage H2 port...-->
-                        <legend.test.h2.port>1975</legend.test.h2.port>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/legend-engine-ide-lsp-default-extensions/pom.xml
+++ b/legend-engine-ide-lsp-default-extensions/pom.xml
@@ -178,6 +178,11 @@
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-language-pure-dsl-service-generation</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-shared-core</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -404,7 +404,7 @@ public abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExt
         return this.protocolMapper;
     }
 
-    protected boolean isEngineServerConfigured()
+    public boolean isEngineServerConfigured()
     {
         return this.engineServerClient.isServerConfigured();
     }
@@ -424,7 +424,7 @@ public abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExt
         return postEngineServer(path, payload, stream -> getProtocolMapper().readValue(stream, responseType));
     }
 
-    protected <T> T postEngineServer(String path, Object payload, ThrowingFunction<InputStream, T> consumer)
+    public <T> T postEngineServer(String path, Object payload, ThrowingFunction<InputStream, T> consumer)
     {
         if (!isEngineServerConfigured())
         {
@@ -713,33 +713,6 @@ public abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExt
         }
     }
 
-    public static class CompileResult extends Result<PureModel>
-    {
-        private final PureModelContextData pureModelContextData;
-
-        private CompileResult(PureModel pureModel, PureModelContextData pureModelContextData)
-        {
-            super(pureModel, null);
-            this.pureModelContextData = pureModelContextData;
-        }
-
-        private CompileResult(Exception e, PureModelContextData pureModelContextData)
-        {
-            super(null, e);
-            this.pureModelContextData = pureModelContextData;
-        }
-
-        public PureModel getPureModel()
-        {
-            return getResult();
-        }
-
-        public PureModelContextData getPureModelContextData()
-        {
-            return this.pureModelContextData;
-        }
-    }
-
     private static class LegendCommandFactory
     {
         public static LegendCommand newCommand(LegendCommandType type, String path, String id, String title, TextLocation textLocation, Map<String, String> arguments, Map<String, LegendInputParameter> inputParameters)
@@ -750,25 +723,5 @@ public abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExt
             }
             return LegendCommand.newCommand(path, id, title, textLocation, arguments, inputParameters);
         }
-    }
-
-    protected interface CommandConsumer
-    {
-        default void accept(String id, String title, SourceInformation sourceInfo)
-        {
-            accept(id, title, sourceInfo, Collections.emptyMap());
-        }
-
-        default void accept(String id, String title, SourceInformation sourceInfo, LegendCommandType type)
-        {
-            accept(id, title, sourceInfo, Collections.emptyMap(), Collections.emptyMap(), type);
-        }
-
-        default void accept(String id, String title, SourceInformation sourceInfo, Map<String, String> arguments)
-        {
-            accept(id, title, sourceInfo, arguments, Collections.emptyMap(), LegendCommandType.SERVER);
-        }
-
-        void accept(String id, String title, SourceInformation sourceInfo, Map<String, String> arguments, Map<String, LegendInputParameter> inputParameters, LegendCommandType type);
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CommandConsumer.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CommandConsumer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension;
+
+import java.util.Collections;
+import java.util.Map;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendCommandType;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendInputParameter;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+
+public interface CommandConsumer
+{
+    default void accept(String id, String title, SourceInformation sourceInfo)
+    {
+        accept(id, title, sourceInfo, Collections.emptyMap());
+    }
+
+    default void accept(String id, String title, SourceInformation sourceInfo, LegendCommandType type)
+    {
+        accept(id, title, sourceInfo, Collections.emptyMap(), Collections.emptyMap(), type);
+    }
+
+    default void accept(String id, String title, SourceInformation sourceInfo, Map<String, String> arguments)
+    {
+        accept(id, title, sourceInfo, arguments, Collections.emptyMap(), LegendCommandType.SERVER);
+    }
+
+    void accept(String id, String title, SourceInformation sourceInfo, Map<String, String> arguments, Map<String, LegendInputParameter> inputParameters, LegendCommandType type);
+}

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CommandsSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CommandsSupport.java
@@ -26,7 +26,7 @@ interface CommandsSupport
 {
     Set<String> getSupportedCommands();
 
-    void collectCommands(SectionState sectionState, PackageableElement element, AbstractLSPGrammarExtension.CommandConsumer consumer);
+    void collectCommands(SectionState sectionState, PackageableElement element, CommandConsumer consumer);
 
     Iterable<? extends LegendExecutionResult> executeCommand(SectionState section, PackageableElement element, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParameters);
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CompileResult.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CompileResult.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension;
+
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+
+public class CompileResult extends AbstractLSPGrammarExtension.Result<PureModel>
+{
+    private final PureModelContextData pureModelContextData;
+
+    CompileResult(PureModel pureModel, PureModelContextData pureModelContextData)
+    {
+        super(pureModel, null);
+        this.pureModelContextData = pureModelContextData;
+    }
+
+    CompileResult(Exception e, PureModelContextData pureModelContextData)
+    {
+        super(null, e);
+        this.pureModelContextData = pureModelContextData;
+    }
+
+    public PureModel getPureModel()
+    {
+        return getResult();
+    }
+
+    public PureModelContextData getPureModelContextData()
+    {
+        return this.pureModelContextData;
+    }
+}

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/FunctionActivatorCommandsSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/FunctionActivatorCommandsSupport.java
@@ -63,7 +63,7 @@ public final class FunctionActivatorCommandsSupport implements CommandsSupport
     }
 
     @Override
-    public void collectCommands(SectionState sectionState, PackageableElement element, AbstractLSPGrammarExtension.CommandConsumer consumer)
+    public void collectCommands(SectionState sectionState, PackageableElement element, CommandConsumer consumer)
     {
         if (element instanceof FunctionActivator && this.extension.isEngineServerConfigured())
         {
@@ -78,7 +78,7 @@ public final class FunctionActivatorCommandsSupport implements CommandsSupport
         TextLocation location = SourceInformationUtil.toLocation(element.sourceInformation);
         String entityPath = element.getPath();
 
-        AbstractLSPGrammarExtension.CompileResult compileResult = this.extension.getCompileResult(section);
+        CompileResult compileResult = this.extension.getCompileResult(section);
         if (compileResult.hasException())
         {
             return Collections.singletonList(this.extension.errorResult(compileResult.getException(), entityPath, location));

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendTDSRequestLambdaBuilder.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendTDSRequestLambdaBuilder.java
@@ -297,9 +297,9 @@ public class LegendTDSRequestLambdaBuilder
         updateParentFunction(expressions, SORT_FUNCTION_NAME, Lists.mutable.of(sortCollection));
     }
 
-    public static List<ValueSpecification> buildLambdaExpressions(ValueSpecification funcBody, TDSRequest request)
+    public static List<ValueSpecification> buildLambdaExpressions(List<ValueSpecification> funcBody, TDSRequest request)
     {
-        List<ValueSpecification> expressions = Lists.mutable.of(funcBody);
+        List<ValueSpecification> expressions = Lists.mutable.withAll(funcBody);
         processFilterOperations(expressions, request.getFilter());
         processGroupByOperations(expressions, request.getGroupBy(), request.getColumns());
         processSortOperations(expressions, request.getSort());

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/TestableCommandsSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/TestableCommandsSupport.java
@@ -193,7 +193,7 @@ public final class TestableCommandsSupport
         // why tryCompile vs getCompileResult:
         // PureModel access is not thread safe, and we could be executing test in parallel
         // hence, this will trigger a compilation per execution required for thread safety
-        AbstractLSPGrammarExtension.CompileResult compileResult = this.extension.tryCompile(section.getDocumentState().getGlobalState(), section.getDocumentState(), section);
+        CompileResult compileResult = this.extension.tryCompile(section.getDocumentState().getGlobalState(), section.getDocumentState(), section);
 
         if (compileResult.hasException())
         {

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
@@ -29,6 +29,7 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.api.list.ListIterable;
 import org.eclipse.collections.api.set.MutableSet;
 import org.finos.legend.engine.ide.lsp.extension.AbstractLegacyParserLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.CommandConsumer;
 import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
 import org.finos.legend.engine.ide.lsp.extension.SourceInformationUtil;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension.core;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.StreamReadFeature;
+import com.fasterxml.jackson.core.StreamWriteFeature;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.temporal.TemporalAccessor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
+import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.CommandConsumer;
+import org.finos.legend.engine.ide.lsp.extension.CompileResult;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendCommandType;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendInputParameter;
+import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.plan.execution.PlanExecutor;
+import org.finos.legend.engine.plan.execution.nodes.helpers.ExecuteNodeParameterTransformationHelper;
+import org.finos.legend.engine.plan.execution.result.ConstantResult;
+import org.finos.legend.engine.plan.execution.result.ErrorResult;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.result.StreamingResult;
+import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
+import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Enumeration;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.Variable;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
+import org.finos.legend.engine.shared.core.identity.factory.IdentityFactoryProvider;
+import org.finos.legend.pure.m4.coreinstance.primitive.date.PureDate;
+import org.finos.legend.pure.m4.coreinstance.primitive.strictTime.PureStrictTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public interface FunctionExecutionSupport
+{
+    Logger LOGGER = LoggerFactory.getLogger(FunctionExecutionSupport.class);
+
+    String EXECUTE_COMMAND_ID = "legend.function.execute";
+    String EXECUTE_COMMAND_TITLE = "Execute";
+
+    AbstractLSPGrammarExtension getExtension();
+
+    Lambda getLambda(PackageableElement element);
+
+    SingleExecutionPlan getExecutionPlan(PackageableElement element, Lambda lambda, PureModel pureModel, Map<String, Object> args);
+
+    static void collectFunctionExecutionCommand(FunctionExecutionSupport executionSupport, PackageableElement element, CompileResult compileResult, CommandConsumer consumer)
+    {
+        List<PackageableElement> elements = compileResult.getPureModelContextData().getElements();
+        Map<String, LegendInputParameter> parameters = Maps.mutable.empty();
+        List<Variable> funcParameters = executionSupport.getLambda(element).parameters;
+        if (funcParameters != null && !funcParameters.isEmpty())
+        {
+            funcParameters.forEach(p ->
+            {
+                PackageableElement paramElement = elements.stream().filter(e -> e.getPath().equals(p._class)).findFirst().orElse(null);
+                if (paramElement instanceof Enumeration)
+                {
+                    parameters.put(p.name, LegendFunctionInputParameter.newFunctionParameter(p, paramElement));
+                }
+                else
+                {
+                    parameters.put(p.name, LegendFunctionInputParameter.newFunctionParameter(p));
+                }
+            });
+        }
+        consumer.accept(EXECUTE_COMMAND_ID, EXECUTE_COMMAND_TITLE, element.sourceInformation, Collections.emptyMap(), parameters, LegendCommandType.CLIENT);
+    }
+
+    static Iterable<? extends LegendExecutionResult> executeFunction(FunctionExecutionSupport executionSupport, SectionState section, String entityPath, Map<String, Object> inputParameters)
+    {
+        AbstractLSPGrammarExtension extension = executionSupport.getExtension();
+
+        CompileResult compileResult = extension.getCompileResult(section);
+        if (compileResult.hasException())
+        {
+            return Collections.singletonList(extension.errorResult(compileResult.getException(), entityPath));
+        }
+
+        MutableList<LegendExecutionResult> results = Lists.mutable.empty();
+        try
+        {
+            PackageableElement element = compileResult.getPureModelContextData().getElements().stream().filter(x -> x.getPath().equals(entityPath)).findFirst().orElseThrow(() -> new IllegalArgumentException("Element " + entityPath + " not found"));
+            Lambda lambda = executionSupport.getLambda(element);
+            PureModel pureModel = compileResult.getPureModel();
+            SingleExecutionPlan executionPlan = executionSupport.getExecutionPlan(element, lambda, pureModel, inputParameters);
+            executePlan(executionSupport, section, executionPlan, entityPath, inputParameters, results);
+        }
+        catch (Exception e)
+        {
+            results.add(extension.errorResult(e, entityPath));
+        }
+        return results;
+    }
+
+    static void executePlan(FunctionExecutionSupport executionSupport, SectionState section, SingleExecutionPlan executionPlan, String entityPath, Map<String, Object> inputParameters, MutableList<LegendExecutionResult> results)
+    {
+        AbstractLSPGrammarExtension extension = executionSupport.getExtension();
+
+        try
+        {
+            if (extension.isEngineServerConfigured())
+            {
+                ExecutionRequest executionRequest = new ExecutionRequest(executionPlan, inputParameters);
+                LegendExecutionResult legendExecutionResult = extension.postEngineServer("/executionPlan/v1/execution/executeRequest?serializationFormat=DEFAULT", executionRequest, is ->
+                {
+                    ByteArrayOutputStream os = new ByteArrayOutputStream(1024);
+                    is.transferTo(os);
+                    return FunctionLegendExecutionResult.newResult(entityPath, LegendExecutionResult.Type.SUCCESS, os.toString(StandardCharsets.UTF_8), "Executed using remote engine server", section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters);
+                });
+                results.add(legendExecutionResult);
+            }
+            else
+            {
+                PlanExecutor planExecutor = PlanExecutor.newPlanExecutorBuilder().withAvailableStoreExecutors().build();
+                MutableMap<String, Result> parametersToConstantResult = Maps.mutable.empty();
+                ExecuteNodeParameterTransformationHelper.buildParameterToConstantResult(executionPlan, inputParameters, parametersToConstantResult);
+                collectResults(executionSupport, entityPath, planExecutor.execute(executionPlan, parametersToConstantResult, "localUser", IdentityFactoryProvider.getInstance().getAnonymousIdentity()), section, inputParameters, results::add);
+            }
+        }
+        catch (Exception e)
+        {
+            results.add(extension.errorResult(e, entityPath));
+        }
+    }
+
+    private static void collectResults(FunctionExecutionSupport executionSupport, String entityPath, org.finos.legend.engine.plan.execution.result.Result result, SectionState section, Map<String, Object> inputParameters, Consumer<? super LegendExecutionResult> consumer)
+    {
+        AbstractLSPGrammarExtension extension = executionSupport.getExtension();
+
+        // TODO also collect results from activities
+        if (result instanceof ErrorResult)
+        {
+            ErrorResult errorResult = (ErrorResult) result;
+            consumer.accept(FunctionLegendExecutionResult.newResult(entityPath, LegendExecutionResult.Type.ERROR, errorResult.getMessage(), errorResult.getTrace(), section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters));
+            return;
+        }
+        if (result instanceof ConstantResult)
+        {
+            consumer.accept(FunctionLegendExecutionResult.newResult(entityPath, LegendExecutionResult.Type.SUCCESS, getConstantResult((ConstantResult) result), null, section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters));
+            return;
+        }
+        if (result instanceof StreamingResult)
+        {
+            ByteArrayOutputStream byteStream = new ByteArrayOutputStream(1024);
+            try
+            {
+                ((StreamingResult) result).getSerializer(SerializationFormat.DEFAULT).stream(byteStream);
+            }
+            catch (IOException e)
+            {
+                consumer.accept(extension.errorResult(e, entityPath));
+                return;
+            }
+            consumer.accept(FunctionLegendExecutionResult.newResult(entityPath, LegendExecutionResult.Type.SUCCESS, byteStream.toString(StandardCharsets.UTF_8), null, section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters));
+            return;
+        }
+        consumer.accept(FunctionLegendExecutionResult.newResult(entityPath, LegendExecutionResult.Type.WARNING, "Unhandled result type: " + result.getClass().getName(), null, section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters));
+    }
+
+    private static String getConstantResult(ConstantResult constantResult)
+    {
+        return getConstantValueResult(constantResult.getValue());
+    }
+
+    JsonMapper functionResultMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
+            .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+            .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+            .enable(SerializationFeature.INDENT_OUTPUT)
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .build());
+
+    private static String getConstantValueResult(Object value)
+    {
+        if (value == null)
+        {
+            return "[]";
+        }
+        if (value instanceof Iterable)
+        {
+            StringBuilder builder = new StringBuilder();
+            ((Iterable<?>) value).forEach(v -> builder.append((builder.length() == 0) ? "[" : ", ").append(getConstantValueResult(v)));
+            return builder.append("]").toString();
+        }
+        if ((value instanceof String) || (value instanceof Boolean) || (value instanceof Number) || (value instanceof PureDate) || (value instanceof PureStrictTime) || (value instanceof TemporalAccessor))
+        {
+            return value.toString();
+        }
+        try
+        {
+            return functionResultMapper.writeValueAsString(value);
+        }
+        catch (Exception e)
+        {
+            LOGGER.error("Error converting value to JSON", e);
+        }
+        return value.toString();
+    }
+
+    class FunctionLegendExecutionResult extends LegendExecutionResult
+    {
+        private final String uri;
+        private final int sectionNum;
+        private final Map<String, Object> inputParameters;
+
+        public FunctionLegendExecutionResult(List<String> ids, Type type, String message, String logMessage, String uri, int sectionNum, Map<String, Object> inputParameters)
+        {
+            super(ids, type, message, logMessage, null);
+            this.uri = uri;
+            this.sectionNum = sectionNum;
+            this.inputParameters = inputParameters;
+        }
+
+        public String getUri()
+        {
+            return uri;
+        }
+
+        public int getSectionNum()
+        {
+            return sectionNum;
+        }
+
+        public Map<String, Object> getInputParameters()
+        {
+            return inputParameters;
+        }
+
+        public static FunctionLegendExecutionResult newResult(String id, Type type, String message, String logMessage, String uri, int sectionNum, Map<String, Object> inputParameters)
+        {
+            return new FunctionLegendExecutionResult(Collections.singletonList(id), type, message, logMessage, uri, sectionNum, inputParameters);
+        }
+    }
+
+    class LegendFunctionInputParameter extends LegendInputParameter
+    {
+        private final Variable variable;
+        private final PackageableElement element;
+
+        private LegendFunctionInputParameter(Variable variable, PackageableElement element)
+        {
+            this.variable = variable;
+            this.element = element;
+        }
+
+        public Variable getVariable()
+        {
+            return this.variable;
+        }
+
+        public PackageableElement getElement()
+        {
+            return this.element;
+        }
+
+        public static LegendFunctionInputParameter newFunctionParameter(Variable variable)
+        {
+            return newFunctionParameter(variable, null);
+        }
+
+        public static LegendFunctionInputParameter newFunctionParameter(Variable variable, PackageableElement element)
+        {
+            return new LegendFunctionInputParameter(variable, element);
+        }
+    }
+
+    class ExecutionRequest
+    {
+        private final ExecutionPlan executionPlan;
+        private final Map<String, Object> executionParameters;
+
+        public ExecutionRequest(ExecutionPlan executionPlan, Map<String, Object> executionParameters)
+        {
+            this.executionPlan = executionPlan;
+            this.executionParameters = executionParameters == null ? Collections.emptyMap() : executionParameters;
+        }
+
+        public ExecutionPlan getExecutionPlan()
+        {
+            return this.executionPlan;
+        }
+
+        public Map<String, Object> getExecutionParameters()
+        {
+            return this.executionParameters;
+        }
+    }
+}

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/LegendTDSRequestHandlerImpl.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/LegendTDSRequestHandlerImpl.java
@@ -16,15 +16,12 @@
 
 package org.finos.legend.engine.ide.lsp.extension.core;
 
-import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtension;
-import org.finos.legend.engine.ide.lsp.extension.features.LegendTDSRequestHandler;
+import org.finos.legend.engine.ide.lsp.extension.CompileResult;
 import org.finos.legend.engine.ide.lsp.extension.LegendTDSRequestLambdaBuilder;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.ColumnType;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.Filter;
@@ -32,19 +29,12 @@ import org.finos.legend.engine.ide.lsp.extension.agGrid.FilterOperation;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.TDSGroupBy;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.TDSRequest;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.features.LegendTDSRequestHandler;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
-import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperValueSpecificationBuilder;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
-import org.finos.legend.engine.plan.generation.PlanGenerator;
-import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
-import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
-import org.finos.legend.engine.plan.platform.PlanPlatform;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Function;
-import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
-import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
-import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
-import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 
 public class LegendTDSRequestHandlerImpl implements LegendTDSRequestHandler
 {
@@ -57,21 +47,25 @@ public class LegendTDSRequestHandlerImpl implements LegendTDSRequestHandler
     @Override
     public LegendExecutionResult executeLegendTDSRequest(SectionState section, String entityPath, TDSRequest request, Map<String, Object> inputParameters)
     {
-        if (!(section.getExtension() instanceof PureLSPGrammarExtension))
+        if (!(section.getExtension() instanceof FunctionExecutionSupport))
         {
-            return LegendExecutionResult.errorResult(new IllegalStateException("Expected pure extensions"), "", entityPath, null);
+            return LegendExecutionResult.errorResult(new IllegalStateException("Not supported extension"), "", entityPath, null);
         }
 
-        PureLSPGrammarExtension extension = (PureLSPGrammarExtension) section.getExtension();
+        FunctionExecutionSupport functionExecutionSupport = (FunctionExecutionSupport) section.getExtension();
+        AbstractLSPGrammarExtension extension = functionExecutionSupport.getExtension();
 
-        AbstractLSPGrammarExtension.CompileResult compileResult = extension.getCompileResult(section);
+        CompileResult compileResult = extension.getCompileResult(section);
         if (compileResult.hasException())
         {
             return extension.errorResult(compileResult.getException(), entityPath);
         }
         MutableList<LegendExecutionResult> results = Lists.mutable.empty();
         PureModel pureModel = compileResult.getPureModel();
-        Function function = (Function) compileResult.getPureModelContextData().getElements().stream().filter(e -> e.getPath().equals(entityPath)).collect(Collectors.toList()).get(0);
+
+        PackageableElement packageableElement = compileResult.getPureModelContextData().getElements().stream().filter(e -> e.getPath().equals(entityPath)).collect(Collectors.toList()).get(0);
+        Lambda lambda = functionExecutionSupport.getLambda(packageableElement);
+
         try
         {
             TDSGroupBy groupBy = request.getGroupBy();
@@ -80,13 +74,13 @@ public class LegendTDSRequestHandlerImpl implements LegendTDSRequestHandler
                 Filter groupFilter = new Filter(groupBy.getColumns().get(index), ColumnType.String, FilterOperation.EQUALS, groupBy.getGroupKeys().get(index));
                 request.getFilter().add(groupFilter);
             }
-            List<ValueSpecification> expressions = LegendTDSRequestLambdaBuilder.buildLambdaExpressions(function.body.get(0), request);
 
-            LambdaFunction<?> queryLambda = HelperValueSpecificationBuilder.buildLambda(expressions, function.parameters, pureModel.getContext());
-            MutableList<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport()));
-            MutableList<PlanTransformer> planTransformers = Iterate.flatCollect(ServiceLoader.load(PlanGeneratorExtension.class), PlanGeneratorExtension::getExtraPlanTransformers, Lists.mutable.empty());
-            SingleExecutionPlan executionPlan = PlanGenerator.generateExecutionPlan(queryLambda, null, null, null, pureModel, null, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
-            extension.executePlan(section, executionPlan, entityPath, inputParameters, results);
+            Lambda newLambda = new Lambda();
+            newLambda.body = LegendTDSRequestLambdaBuilder.buildLambdaExpressions(lambda.body, request);
+            newLambda.parameters = lambda.parameters;
+
+            SingleExecutionPlan executionPlan = functionExecutionSupport.getExecutionPlan(packageableElement, newLambda, pureModel, inputParameters);
+            FunctionExecutionSupport.executePlan(functionExecutionSupport, section, executionPlan, entityPath, inputParameters, results);
         }
         catch (Exception e)
         {

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
@@ -38,6 +38,8 @@ import org.eclipse.collections.impl.lazy.CompositeIterable;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.ide.lsp.extension.AbstractLegacyParserLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.CommandConsumer;
+import org.finos.legend.engine.ide.lsp.extension.CompileResult;
 import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
 import org.finos.legend.engine.ide.lsp.extension.SourceInformationUtil;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
@@ -24,6 +24,8 @@ import java.util.stream.Stream;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.finos.legend.engine.ide.lsp.extension.AbstractSectionParserLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.CommandConsumer;
+import org.finos.legend.engine.ide.lsp.extension.CompileResult;
 import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
 import org.finos.legend.engine.ide.lsp.extension.SourceInformationUtil;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/core/TestPureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/core/TestPureLSPGrammarExtension.java
@@ -425,7 +425,7 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
         SectionState sectionState = newSectionState("docId", code);
         List<? extends LegendCommand> commands = Lists.mutable.ofAll(this.extension.getCommands(sectionState))
                 .sortThis(Comparator.comparing(LegendCommand::getId).thenComparing(x -> x.getLocation().getTextInterval().getStart().getLine()));
-        Set<String> expectedCommands = Set.of(PureLSPGrammarExtension.EXEC_FUNCTION_WITH_PARAMETERS_ID, PureLSPGrammarExtension.ACTIVATE_FUNCTION_ID);
+        Set<String> expectedCommands = Set.of(FunctionExecutionSupport.EXECUTE_COMMAND_ID, PureLSPGrammarExtension.ACTIVATE_FUNCTION_ID);
         Set<String> actualCommands = Sets.mutable.empty();
         commands.forEach(c -> actualCommands.add(c.getId()));
         Assertions.assertEquals(expectedCommands, actualCommands);

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
@@ -16,17 +16,24 @@
 
 package org.finos.legend.engine.ide.lsp.extension.service;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
-
+import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.factory.Sets;
+import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.finos.legend.engine.ide.lsp.extension.AbstractLSPGrammarExtensionTest;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
+import org.finos.legend.engine.ide.lsp.extension.core.FunctionExecutionSupport;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Kind;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic.Source;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendCommand;
 import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
+import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.junit.jupiter.api.Assertions;
@@ -45,23 +52,23 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
     {
         testGetDeclarations(
                 "###Service\n" +
-                        "\r\n" +
+                        "\n" +
                         "\n" +
                         "Service test::services::TestService\n" +
-                        "{\r\n" +
+                        "{\n" +
                         "    pattern : 'test';\n" +
-                        "    documentation : 'service for testing';\r\n" +
+                        "    documentation : 'service for testing';\n" +
                         "    execution : Single\n" +
                         "    {\n" +
                         "        query : src:test::model::TestClass[1] | $src.name;\n" +
                         "        mapping : test::mappings::TestMapping;\n" +
-                        "        runtime : test::runtimes::TestRuntime;\r\n" +
+                        "        runtime : test::runtimes::TestRuntime;\n" +
                         "    }\n" +
                         "    test : Single" +
                         "    {\n" +
                         "        data : '';\n" +
                         "        asserts : [];\n" +
-                        "    }\r\n" +
+                        "    }\n" +
                         "}\n",
                 LegendDeclaration.builder().withIdentifier("test::services::TestService").withClassifier("meta::legend::service::metamodel::Service").withLocation(DOC_ID_FOR_TEXT,3, 0, 17, 0).build()
         );
@@ -143,141 +150,149 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         Assertions.assertEquals(Set.of("Service", "ExecutionEnvironment"), antlrExpectedTokens);
     }
 
-    @Test
-    public void testGetReferenceResolvers()
+    private static final String TEST_RUNTIME_DOC_ID = "vscodelsp::test::H2Runtime";
+    private static final String TEST_MAPPING_DOC_ID = "vscodelsp::test::EmployeeMapping";
+    private static final String TEST_STORE_DOC_ID_1 = "vscodelsp::test::TestDB1";
+    private static final String TEST_STORE_DOC_ID_2 = "vscodelsp::test::TestDB2";
+    private static final String TEST_CONNECTION_DOC_ID_1 = "vscodelsp::test::LocalH2Connection1";
+    private static final String TEST_CONNECTION_DOC_ID_2 = "vscodelsp::test::LocalH2Connection2";
+    private static final String TEST_SERVICE_DOC_ID = "vscodelsp::test::TestService";
+
+    private MutableMap<String, String> getCodeFilesThatParseCompile()
     {
         MutableMap<String, String> codeFiles = Maps.mutable.empty();
-        final String TEST_RUNTIME_DOC_ID = "vscodelsp::test::H2Runtime";
-        final String TEST_MAPPING_DOC_ID = "vscodelsp::test::EmployeeMapping";
-        final String TEST_STORE_DOC_ID_1 = "vscodelsp::test::TestDB1";
-        final String TEST_STORE_DOC_ID_2 = "vscodelsp::test::TestDB2";
-        final String TEST_CONNECTION_DOC_ID_1 = "vscodelsp::test::LocalH2Connection1";
-        final String TEST_CONNECTION_DOC_ID_2 = "vscodelsp::test::LocalH2Connection2";
-        final String TEST_SERVICE_DOC_ID = "vscodelsp::test::TestService";
         codeFiles.put("vscodelsp::test::Employee",
                 "###Pure\n" +
-                "Class vscodelsp::test::Employee\n" +
-                "{\n" +
-                "    foobar: Float[1];\n" +
-                "    hireDate : Date[1];\n" +
-                "    hireType : String[1];\n" +
-                "}");
+                        "Class vscodelsp::test::Employee\n" +
+                        "{\n" +
+                        "    foobar: Float[1];\n" +
+                        "    hireDate : Date[1];\n" +
+                        "    hireType : String[1];\n" +
+                        "}");
 
         codeFiles.put("vscodelsp::test::EmployeeSrc",
                 "###Pure\n" +
-                "Class vscodelsp::test::EmployeeSrc\n" +
-                "{\n" +
-                "    foobar: Float[1];\n" +
-                "    hireDate : Date[1];\n" +
-                "    hireType : String[1];\n" +
-                "}");
+                        "Class vscodelsp::test::EmployeeSrc\n" +
+                        "{\n" +
+                        "    foobar: Float[1];\n" +
+                        "    hireDate : Date[1];\n" +
+                        "    hireType : String[1];\n" +
+                        "}");
 
         codeFiles.put(TEST_MAPPING_DOC_ID,
                 "###Mapping\n" +
-                "Mapping vscodelsp::test::EmployeeMapping\n" +
-                "(\n" +
-                "   vscodelsp::test::Employee[emp] : Pure\n" +
-                "   {\n" +
-                "      ~src vscodelsp::test::EmployeeSrc\n" +
-                "      hireDate : today(),\n" +
-                "      hireType : 'FullTime'\n" +
-                "   }\n" +
-                ")");
+                        "Mapping vscodelsp::test::EmployeeMapping\n" +
+                        "(\n" +
+                        "   vscodelsp::test::Employee[emp] : Pure\n" +
+                        "   {\n" +
+                        "      ~src vscodelsp::test::EmployeeSrc\n" +
+                        "      hireDate : today(),\n" +
+                        "      hireType : 'FullTime'\n" +
+                        "   }\n" +
+                        ")");
 
         codeFiles.put(TEST_STORE_DOC_ID_1,
                 "###Relational\n" +
-                "Database vscodelsp::test::TestDB1\n" +
-                "(\n" +
-                "   Table PersonTable\n" +
-                "   (\n" +
-                "       id INTEGER PRIMARY KEY,\n" +
-                "       firm_id INTEGER,\n" +
-                "       firstName VARCHAR(200),\n" +
-                "       lastName VARCHAR(200)\n" +
-                "   )\n" +
-                ")");
+                        "Database vscodelsp::test::TestDB1\n" +
+                        "(\n" +
+                        "   Table PersonTable\n" +
+                        "   (\n" +
+                        "       id INTEGER PRIMARY KEY,\n" +
+                        "       firm_id INTEGER,\n" +
+                        "       firstName VARCHAR(200),\n" +
+                        "       lastName VARCHAR(200)\n" +
+                        "   )\n" +
+                        ")");
 
         codeFiles.put(TEST_CONNECTION_DOC_ID_1,
                 "###Connection\n" +
-                "RelationalDatabaseConnection vscodelsp::test::LocalH2Connection1\n" +
-                "{\n" +
-                "   store: vscodelsp::test::TestDB1;\n" +
-                "   type: H2;\n" +
-                "   specification: LocalH2\n" +
-                "   {\n" +
-                "       testDataSetupSqls: [\n" +
-                "           'Drop table if exists FirmTable;\\nDrop table if exists PersonTable;\\nCreate Table FirmTable(id INT, Type VARCHAR(200), Legal_Name VARCHAR(200));\\nCreate Table PersonTable(id INT, firm_id INT, lastName VARCHAR(200), firstName VARCHAR(200));\\nInsert into FirmTable (id, Type, Legal_Name) values (1,\\'LLC\\',\\'FirmA\\');\\nInsert into FirmTable (id, Type, Legal_Name) values (2,\\'CORP\\',\\'Apple\\');\\nInsert into PersonTable (id, firm_id, lastName, firstName) values (1, 1, \\'John\\', \\'Doe\\');\\n\\n\\n'\n" +
-                "           ];\n" +
-                "   };\n" +
-                "   auth: DefaultH2;\n" +
-                "}");
+                        "RelationalDatabaseConnection vscodelsp::test::LocalH2Connection1\n" +
+                        "{\n" +
+                        "   store: vscodelsp::test::TestDB1;\n" +
+                        "   type: H2;\n" +
+                        "   specification: LocalH2\n" +
+                        "   {\n" +
+                        "       testDataSetupSqls: [\n" +
+                        "           'Drop table if exists FirmTable;\\nDrop table if exists PersonTable;\\nCreate Table FirmTable(id INT, Type VARCHAR(200), Legal_Name VARCHAR(200));\\nCreate Table PersonTable(id INT, firm_id INT, lastName VARCHAR(200), firstName VARCHAR(200));\\nInsert into FirmTable (id, Type, Legal_Name) values (1,\\'LLC\\',\\'FirmA\\');\\nInsert into FirmTable (id, Type, Legal_Name) values (2,\\'CORP\\',\\'Apple\\');\\nInsert into PersonTable (id, firm_id, lastName, firstName) values (1, 1, \\'John\\', \\'Doe\\');\\n\\n\\n'\n" +
+                        "           ];\n" +
+                        "   };\n" +
+                        "   auth: DefaultH2;\n" +
+                        "}");
 
         codeFiles.put(TEST_STORE_DOC_ID_2,
                 "###Relational\n" +
-                "Database vscodelsp::test::TestDB2\n" +
-                "(\n" +
-                "   Table FirmTable\n" +
-                "   (\n" +
-                "       id INTEGER PRIMARY KEY,\n" +
-                "       Type VARCHAR(200),\n" +
-                "       Legal_name VARCHAR(200)\n" +
-                "   )\n" +
-                ")");
+                        "Database vscodelsp::test::TestDB2\n" +
+                        "(\n" +
+                        "   Table FirmTable\n" +
+                        "   (\n" +
+                        "       id INTEGER PRIMARY KEY,\n" +
+                        "       Type VARCHAR(200),\n" +
+                        "       Legal_name VARCHAR(200)\n" +
+                        "   )\n" +
+                        ")");
 
         codeFiles.put(TEST_CONNECTION_DOC_ID_2,
                 "###Connection\n" +
-                "RelationalDatabaseConnection vscodelsp::test::LocalH2Connection2\n" +
-                "{\n" +
-                "   store: vscodelsp::test::TestDB2;\n" +
-                "   type: H2;\n" +
-                "   specification: LocalH2\n" +
-                "   {\n" +
-                "       testDataSetupSqls: [\n" +
-                "           'Drop table if exists FirmTable;\\nDrop table if exists PersonTable;\\nCreate Table FirmTable(id INT, Type VARCHAR(200), Legal_Name VARCHAR(200));\\nCreate Table PersonTable(id INT, firm_id INT, lastName VARCHAR(200), firstName VARCHAR(200));\\nInsert into FirmTable (id, Type, Legal_Name) values (1,\\'LLC\\',\\'FirmA\\');\\nInsert into FirmTable (id, Type, Legal_Name) values (2,\\'CORP\\',\\'Apple\\');\\nInsert into PersonTable (id, firm_id, lastName, firstName) values (1, 1, \\'John\\', \\'Doe\\');\\n\\n\\n'\n" +
-                "           ];\n" +
-                "   };\n" +
-                "   auth: DefaultH2;\n" +
-                "}");
+                        "RelationalDatabaseConnection vscodelsp::test::LocalH2Connection2\n" +
+                        "{\n" +
+                        "   store: vscodelsp::test::TestDB2;\n" +
+                        "   type: H2;\n" +
+                        "   specification: LocalH2\n" +
+                        "   {\n" +
+                        "       testDataSetupSqls: [\n" +
+                        "           'Drop table if exists FirmTable;\\nDrop table if exists PersonTable;\\nCreate Table FirmTable(id INT, Type VARCHAR(200), Legal_Name VARCHAR(200));\\nCreate Table PersonTable(id INT, firm_id INT, lastName VARCHAR(200), firstName VARCHAR(200));\\nInsert into FirmTable (id, Type, Legal_Name) values (1,\\'LLC\\',\\'FirmA\\');\\nInsert into FirmTable (id, Type, Legal_Name) values (2,\\'CORP\\',\\'Apple\\');\\nInsert into PersonTable (id, firm_id, lastName, firstName) values (1, 1, \\'John\\', \\'Doe\\');\\n\\n\\n'\n" +
+                        "           ];\n" +
+                        "   };\n" +
+                        "   auth: DefaultH2;\n" +
+                        "}");
 
         codeFiles.put(TEST_RUNTIME_DOC_ID,
                 "###Runtime\n" +
-                "Runtime vscodelsp::test::H2Runtime\n" +
-                "{\n" +
-                "   mappings:\n" +
-                "   [\n" +
-                "       vscodelsp::test::EmployeeMapping\n" +
-                "   ];\n" +
-                "   connections:\n" +
-                "   [\n" +
-                "       vscodelsp::test::TestDB1:\n" +
-                "       [\n" +
-                "           connection_1: vscodelsp::test::LocalH2Connection1\n" +
-                "       ],\n" +
-                "       vscodelsp::test::TestDB2:\n" +
-                "       [\n" +
-                "           connection_2: vscodelsp::test::LocalH2Connection2\n" +
-                "       ]\n" +
-                "   ];\n" +
-                "}");
+                        "Runtime vscodelsp::test::H2Runtime\n" +
+                        "{\n" +
+                        "   mappings:\n" +
+                        "   [\n" +
+                        "       vscodelsp::test::EmployeeMapping\n" +
+                        "   ];\n" +
+                        "   connections:\n" +
+                        "   [\n" +
+                        "       vscodelsp::test::TestDB1:\n" +
+                        "       [\n" +
+                        "           connection_1: vscodelsp::test::LocalH2Connection1\n" +
+                        "       ],\n" +
+                        "       vscodelsp::test::TestDB2:\n" +
+                        "       [\n" +
+                        "           connection_2: vscodelsp::test::LocalH2Connection2\n" +
+                        "       ]\n" +
+                        "   ];\n" +
+                        "}");
 
         codeFiles.put(TEST_SERVICE_DOC_ID,
                 "###Service\n" +
-                "Service vscodelsp::test::TestService\n" +
-                "{\n" +
-                "    pattern : 'test';\n" +
-                "    documentation : 'service for testing';\n" +
-                "    execution : Single\n" +
-                "    {\n" +
-                "        query : src:vscodelsp::test::Employee[1] | $src.hireType;\n" +
-                "        mapping : vscodelsp::test::EmployeeMapping;\n" +
-                "        runtime : vscodelsp::test::H2Runtime;\n" +
-                "    }\n" +
-                "    test : Single" +
-                "    {\n" +
-                "        data : '';\n" +
-                "        asserts : [];\n" +
-                "    }\n" +
-                "}");
+                        "Service vscodelsp::test::TestService\n" +
+                        "{\n" +
+                        "    pattern : 'test';\n" +
+                        "    documentation : 'service for testing';\n" +
+                        "    execution : Single\n" +
+                        "    {\n" +
+                        "        query : src:vscodelsp::test::Employee[1] | $src.hireType;\n" +
+                        "        mapping : vscodelsp::test::EmployeeMapping;\n" +
+                        "        runtime : vscodelsp::test::H2Runtime;\n" +
+                        "    }\n" +
+                        "    test : Single" +
+                        "    {\n" +
+                        "        data : '';\n" +
+                        "        asserts : [];\n" +
+                        "    }\n" +
+                        "}");
+
+        return codeFiles;
+    }
+
+    @Test
+    public void testGetReferenceResolvers()
+    {
+        MutableMap<String, String> codeFiles = this.getCodeFilesThatParseCompile();
 
         LegendReference mappedMappingReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_SERVICE_DOC_ID, 8, 18, 8, 49))
@@ -292,5 +307,21 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
                 .build();
 
         testReferenceLookup(codeFiles, TEST_SERVICE_DOC_ID, TextPosition.newPosition(9, 41), mappedRuntimeReference, "Within the runtime name has been mapped, referring to runtime definition");
+    }
+
+
+    @Test
+    public void testCommands()
+    {
+        MutableMap<String, String> codeFiles = this.getCodeFilesThatParseCompile();
+        MutableList<SectionState> sectionStates = newSectionStates(codeFiles);
+        SectionState sectionState = sectionStates.select(x -> x.getExtension() instanceof ServiceLSPGrammarExtension).getOnly();
+
+        List<? extends LegendCommand> commands = Lists.mutable.ofAll(this.extension.getCommands(sectionState))
+                .sortThis(Comparator.comparing(LegendCommand::getId).thenComparing(x -> x.getLocation().getTextInterval().getStart().getLine()));
+        Set<String> expectedCommands = Set.of(FunctionExecutionSupport.EXECUTE_COMMAND_ID, ServiceLSPGrammarExtension.RUN_LEGACY_TESTS_COMMAND_ID);
+        Set<String> actualCommands = Sets.mutable.empty();
+        commands.forEach(c -> actualCommands.add(c.getId()));
+        Assertions.assertEquals(expectedCommands, actualCommands);
     }
 }

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
@@ -15,7 +15,9 @@
 package org.finos.legend.engine.ide.lsp.server;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.ToNumberPolicy;
 import com.google.gson.reflect.TypeToken;
 import java.io.File;
 import java.io.InputStream;
@@ -115,7 +117,7 @@ public class LegendLanguageServer implements LegendLanguageServerContract
     private final boolean async;
     private final LegendServerGlobalState globalState = new LegendServerGlobalState(this);
     private final AtomicInteger progressId = new AtomicInteger();
-    private final Gson gson = new Gson();
+    private final Gson gson = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
     private final Set<String> rootFolders = Collections.synchronizedSet(new HashSet<>());
 
     private LegendLanguageServer(boolean async, Executor executor, ClasspathFactory classpathFactory, LegendLSPGrammarLibrary grammars, Collection<LegendLSPFeature> features)


### PR DESCRIPTION
Abstract required APIs for execution (**_FunctionExecutionSupport_**), so that function and services can share the core code.

This also move inner classes out so are easy to import and reuse.

Last - this fixes a bug with function parameter handling, where integers were handled as doubles. 