### PR TITLE
Merge core and extra dependencies into single pom

### DIFF
--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/classpath/ClasspathUsingMavenFactory.java
@@ -431,16 +431,17 @@ public class ClasspathUsingMavenFactory implements ClasspathFactory
         }
         finally
         {
-            try
+            if (tempPom != null)
             {
-                if (tempPom != null)
+                try
                 {
                     Files.delete(tempPom);
                 }
-            }
-            catch (IOException e)
-            {
-                LOGGER.error("Failed to delete temp pom", e);
+                catch (IOException e)
+                {
+                    LOGGER.error("Failed to delete temp pom: {}", tempPom, e);
+                    tempPom.toFile().deleteOnExit();
+                }
             }
         }
     }
@@ -457,7 +458,7 @@ public class ClasspathUsingMavenFactory implements ClasspathFactory
             throw new IOException("Cannot read pom model", e);
         }
 
-        Path tempPom = pom.getParent().resolve("legend_extension_temp_pom.xml");
+        Path tempPom = Files.createTempFile(pom.getParent(), "legend_extension_pom", ".xml");
 
         try (OutputStream pomOs = Files.newOutputStream(tempPom))
         {


### PR DESCRIPTION
Merge core and extra dependencies into single pom to avoid multiple maven calls, and better handling transitive dependencies, such that same dependencies but different version will be decided by user pom or maven resolution rules.