### PR TITLE
Allow to get entities for specific documents

### DIFF
--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/request/LegendEntitiesRequest.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/request/LegendEntitiesRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.server.request;
+
+import java.util.List;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.util.Preconditions;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+public class LegendEntitiesRequest
+{
+    @NonNull
+    private List<TextDocumentIdentifier> textDocuments;
+
+    public LegendEntitiesRequest()
+    {
+        this(List.of());
+    }
+
+    public LegendEntitiesRequest(@NonNull List<TextDocumentIdentifier> textDocuments)
+    {
+        this.setTextDocuments(textDocuments);
+    }
+
+    public List<TextDocumentIdentifier> getTextDocuments()
+    {
+        return this.textDocuments;
+    }
+
+    public void setTextDocuments(@NonNull List<TextDocumentIdentifier> textDocument)
+    {
+        this.textDocuments = Preconditions.checkNotNull(textDocument, "textDocuments");
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/service/LegendLanguageServiceContract.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/service/LegendLanguageServiceContract.java
@@ -24,6 +24,7 @@ import org.finos.legend.engine.ide.lsp.extension.LegendEntity;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.test.LegendTest;
 import org.finos.legend.engine.ide.lsp.extension.test.LegendTestExecutionResult;
+import org.finos.legend.engine.ide.lsp.server.request.LegendEntitiesRequest;
 
 @JsonSegment("legend")
 public interface LegendLanguageServiceContract
@@ -44,6 +45,6 @@ public interface LegendLanguageServiceContract
     CompletableFuture<String> loadLegendVirtualFile(String uri);
 
     @JsonRequest("entities")
-    CompletableFuture<List<LegendEntity>> entities();
+    CompletableFuture<List<LegendEntity>> entities(LegendEntitiesRequest request);
 
 }


### PR DESCRIPTION
Allow to get entities for specific documents to allow VSCode to just get a subset of entities that belong to a file that actually changed, avoiding getting the full list, including entities that user did not edited.  