### PR TITLE
Support for reference LSP API

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendReferenceResolver.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendReferenceResolver.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import org.finos.legend.engine.ide.lsp.extension.text.Locatable;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.CompileContext;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.SourceInformationHelper;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.pure.m4.coreinstance.CoreInstance;
 import org.slf4j.Logger;
@@ -59,13 +60,18 @@ public class LegendReferenceResolver implements Locatable
         }
     }
 
-    public static LegendReferenceResolver newReferenceResolver(SourceInformation location, Function<CompileContext, CoreInstance> gotoResolver)
+    public static Optional<LegendReferenceResolver> newReferenceResolver(SourceInformation location, Function<CompileContext, CoreInstance> gotoResolver)
     {
-        return new LegendReferenceResolver(SourceInformationUtil.toLocation(location), gotoResolver);
+        if (!SourceInformationUtil.isValidSourceInfo(location))
+        {
+            return Optional.empty();
+        }
+
+        return Optional.of(new LegendReferenceResolver(SourceInformationUtil.toLocation(location), gotoResolver));
     }
 
-    public static LegendReferenceResolver newReferenceResolver(org.finos.legend.pure.m4.coreinstance.SourceInformation location, CoreInstance coreInstance)
+    public static Optional<LegendReferenceResolver> newReferenceResolver(org.finos.legend.pure.m4.coreinstance.SourceInformation location, CoreInstance coreInstance)
     {
-        return new LegendReferenceResolver(SourceInformationUtil.toLocation(location), x -> coreInstance);
+        return LegendReferenceResolver.newReferenceResolver(SourceInformationHelper.fromM3SourceInformation(location), x -> coreInstance);
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/SourceInformationUtil.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/SourceInformationUtil.java
@@ -42,4 +42,20 @@ public final class SourceInformationUtil
     {
         return TextLocation.newTextSource(sourceInfo.getSourceId(), sourceInfo.getStartLine() - 1, sourceInfo.getStartColumn() - 1, sourceInfo.getEndLine() - 1, sourceInfo.getEndColumn() - 1);
     }
+
+    /**
+     * Check if the source information is valid.
+     *
+     * @param sourceInfo source information
+     * @return whether source information is valid
+     */
+    public static boolean isValidSourceInfo(SourceInformation sourceInfo)
+    {
+        return (sourceInfo != null) &&
+                (sourceInfo != SourceInformation.getUnknownSourceInformation()) &&
+                (sourceInfo.startLine > 0) &&
+                (sourceInfo.startColumn > 0) &&
+                (sourceInfo.startLine <= sourceInfo.endLine) &&
+                ((sourceInfo.startLine == sourceInfo.endLine) ? (sourceInfo.startColumn <= sourceInfo.endColumn) : (sourceInfo.endColumn > 0));
+    }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
@@ -17,12 +17,10 @@
 package org.finos.legend.engine.ide.lsp.extension.connection;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
@@ -155,53 +153,53 @@ public class ConnectionLSPGrammarExtension extends AbstractLegacyParserLSPGramma
     }
 
     @Override
-    protected Collection<LegendReferenceResolver> getReferenceResolvers(SectionState section, PackageableElement packageableElement, Optional<CoreInstance> coreInstance)
+    protected Stream<Optional<LegendReferenceResolver>> getReferenceResolvers(SectionState section, PackageableElement packageableElement, Optional<CoreInstance> coreInstance)
     {
         if (!(packageableElement instanceof PackageableConnection))
         {
-            return List.of();
+            return Stream.empty();
         }
 
-        return this.getConnectionReferences(((PackageableConnection) packageableElement).connectionValue, section.getDocumentState().getGlobalState()).collect(Collectors.toList());
+        return this.getConnectionReferences(((PackageableConnection) packageableElement).connectionValue, section.getDocumentState().getGlobalState());
     }
 
-    public Stream<LegendReferenceResolver> getConnectionReferences(Connection connection, GlobalState state)
+    public Stream<Optional<LegendReferenceResolver>> getConnectionReferences(Connection connection, GlobalState state)
     {
-        Stream<LegendReferenceResolver> connectionReferences = connection.accept(new ConnectionVisitor<>()
+        Stream<Optional<LegendReferenceResolver>> connectionReferences = connection.accept(new ConnectionVisitor<>()
         {
             @Override
-            public Stream<LegendReferenceResolver> visit(Connection connection)
+            public Stream<Optional<LegendReferenceResolver>> visit(Connection connection)
             {
                 return state.findGrammarExtensionThatImplements(ConnectionLSPGrammarProvider.class)
                         .flatMap(x -> x.getConnectionReferences(connection, state));
             }
 
             @Override
-            public Stream<LegendReferenceResolver> visit(ConnectionPointer connectionPointer)
+            public Stream<Optional<LegendReferenceResolver>> visit(ConnectionPointer connectionPointer)
             {
                 return Stream.of(LegendReferenceResolver.newReferenceResolver(connectionPointer.sourceInformation, c -> c.resolveConnection(connectionPointer.connection, connectionPointer.sourceInformation)));
             }
 
             @Override
-            public Stream<LegendReferenceResolver> visit(ModelConnection modelConnection)
+            public Stream<Optional<LegendReferenceResolver>> visit(ModelConnection modelConnection)
             {
                 return Stream.empty();
             }
 
             @Override
-            public Stream<LegendReferenceResolver> visit(JsonModelConnection jsonModelConnection)
+            public Stream<Optional<LegendReferenceResolver>> visit(JsonModelConnection jsonModelConnection)
             {
                 return Stream.of(LegendReferenceResolver.newReferenceResolver(jsonModelConnection.classSourceInformation, c -> c.resolveClass(jsonModelConnection._class, jsonModelConnection.classSourceInformation)));
             }
 
             @Override
-            public Stream<LegendReferenceResolver> visit(XmlModelConnection xmlModelConnection)
+            public Stream<Optional<LegendReferenceResolver>> visit(XmlModelConnection xmlModelConnection)
             {
                 return Stream.of(LegendReferenceResolver.newReferenceResolver(xmlModelConnection.classSourceInformation, c -> c.resolveClass(xmlModelConnection._class, xmlModelConnection.classSourceInformation)));
             }
 
             @Override
-            public Stream<LegendReferenceResolver> visit(ModelChainConnection modelChainConnection)
+            public Stream<Optional<LegendReferenceResolver>> visit(ModelChainConnection modelChainConnection)
             {
                 // TODO: Refactor ModelChainConnection to contain List<PackageableElementPointer> in order to reference the mappings
                 return Stream.empty();

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarProvider.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarProvider.java
@@ -16,6 +16,7 @@
 
 package org.finos.legend.engine.ide.lsp.extension.connection;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
@@ -23,6 +24,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.connect
 
 public interface ConnectionLSPGrammarProvider
 {
-    Stream<LegendReferenceResolver> getConnectionReferences(Connection connection, GlobalState state);
+    Stream<Optional<LegendReferenceResolver>> getConnectionReferences(Connection connection, GlobalState state);
 
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/DefaultFunctionExpressionNavigator.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/DefaultFunctionExpressionNavigator.java
@@ -24,5 +24,5 @@ import java.util.stream.Stream;
 
 public interface DefaultFunctionExpressionNavigator
 {
-    Stream<LegendReferenceResolver> findReferences(Optional<CoreInstance> coreInstance);
+    Stream<Optional<LegendReferenceResolver>> findReferences(Optional<CoreInstance> coreInstance);
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PackageableElementDefaultVisitor.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PackageableElementDefaultVisitor.java
@@ -16,6 +16,8 @@
 
 package org.finos.legend.engine.ide.lsp.extension.core;
 
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElementVisitor;
@@ -31,78 +33,76 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.PackageableRuntime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.SectionIndex;
 
-import java.util.stream.Stream;
-
-public class PackageableElementDefaultVisitor implements PackageableElementVisitor<Stream<LegendReferenceResolver>>
+public class PackageableElementDefaultVisitor implements PackageableElementVisitor<Stream<Optional<LegendReferenceResolver>>>
 {
     @Override
-    public Stream<LegendReferenceResolver> visit(PackageableElement packageableElement)
+    public Stream<Optional<LegendReferenceResolver>> visit(PackageableElement packageableElement)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(Profile profile)
+    public Stream<Optional<LegendReferenceResolver>> visit(Profile profile)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(Enumeration enumeration)
+    public Stream<Optional<LegendReferenceResolver>> visit(Enumeration enumeration)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(Class aClass)
+    public Stream<Optional<LegendReferenceResolver>> visit(Class aClass)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(Association association)
+    public Stream<Optional<LegendReferenceResolver>> visit(Association association)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(Function function)
+    public Stream<Optional<LegendReferenceResolver>> visit(Function function)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(Measure measure)
+    public Stream<Optional<LegendReferenceResolver>> visit(Measure measure)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(SectionIndex sectionIndex)
+    public Stream<Optional<LegendReferenceResolver>> visit(SectionIndex sectionIndex)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(Mapping mapping)
+    public Stream<Optional<LegendReferenceResolver>> visit(Mapping mapping)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(PackageableRuntime packageableRuntime)
+    public Stream<Optional<LegendReferenceResolver>> visit(PackageableRuntime packageableRuntime)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(PackageableConnection packageableConnection)
+    public Stream<Optional<LegendReferenceResolver>> visit(PackageableConnection packageableConnection)
     {
         return Stream.empty();
     }
 
     @Override
-    public Stream<LegendReferenceResolver> visit(DataElement dataElement)
+    public Stream<Optional<LegendReferenceResolver>> visit(DataElement dataElement)
     {
         return Stream.empty();
     }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PureLSPGrammarExtension.java
@@ -16,7 +16,6 @@
 
 package org.finos.legend.engine.ide.lsp.extension.core;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -169,29 +168,29 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
     }
 
     @Override
-    protected Collection<LegendReferenceResolver> getReferenceResolvers(SectionState section, PackageableElement packageableElement, Optional<CoreInstance> coreInstance)
+    protected Stream<Optional<LegendReferenceResolver>> getReferenceResolvers(SectionState section, PackageableElement packageableElement, Optional<CoreInstance> coreInstance)
     {
-        Stream<LegendReferenceResolver> pureReferences = packageableElement.accept(new PackageableElementDefaultVisitor()
+        Stream<Optional<LegendReferenceResolver>> pureReferences = packageableElement.accept(new PackageableElementDefaultVisitor()
         {
             @Override
-            public Stream<LegendReferenceResolver> visit(Function function)
+            public Stream<Optional<LegendReferenceResolver>> visit(Function function)
             {
-                Stream<LegendReferenceResolver> stereotypeReferences = toStereotypeReferences(function.stereotypes);
-                Stream<LegendReferenceResolver> taggedValueReferences = toTaggedValueReferences(function.taggedValues);
-                Stream<LegendReferenceResolver> coreReferences = FUNCTION_EXPRESSION_NAVIGATOR.findReferences(coreInstance);
+                Stream<Optional<LegendReferenceResolver>> stereotypeReferences = toStereotypeReferences(function.stereotypes);
+                Stream<Optional<LegendReferenceResolver>> taggedValueReferences = toTaggedValueReferences(function.taggedValues);
+                Stream<Optional<LegendReferenceResolver>> coreReferences = FUNCTION_EXPRESSION_NAVIGATOR.findReferences(coreInstance);
                 return Stream.of(stereotypeReferences, taggedValueReferences, coreReferences)
                         .flatMap(java.util.function.Function.identity());
             }
 
             @Override
-            public Stream<LegendReferenceResolver> visit(Class clazz)
+            public Stream<Optional<LegendReferenceResolver>> visit(Class clazz)
             {
-                Stream<LegendReferenceResolver> milestonedPropertyReferences = toPropertyReferences(clazz.originalMilestonedProperties);
-                Stream<LegendReferenceResolver> propertyReferences = toPropertyReferences(clazz.properties);
-                Stream<LegendReferenceResolver> stereotypeReferences = toStereotypeReferences(clazz.stereotypes);
-                Stream<LegendReferenceResolver> taggedValueReferences = toTaggedValueReferences(clazz.taggedValues);
-                Stream<LegendReferenceResolver> qualifiedPropertyReferences = toQualifiedPropertyReferences(clazz.qualifiedProperties);
-                Stream<LegendReferenceResolver> coreReferences = Stream.empty();
+                Stream<Optional<LegendReferenceResolver>> milestonedPropertyReferences = toPropertyReferences(clazz.originalMilestonedProperties);
+                Stream<Optional<LegendReferenceResolver>> propertyReferences = toPropertyReferences(clazz.properties);
+                Stream<Optional<LegendReferenceResolver>> stereotypeReferences = toStereotypeReferences(clazz.stereotypes);
+                Stream<Optional<LegendReferenceResolver>> taggedValueReferences = toTaggedValueReferences(clazz.taggedValues);
+                Stream<Optional<LegendReferenceResolver>> qualifiedPropertyReferences = toQualifiedPropertyReferences(clazz.qualifiedProperties);
+                Stream<Optional<LegendReferenceResolver>> coreReferences = Stream.empty();
                 if (coreInstance.isPresent())
                 {
                     coreReferences = toReferences((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class) coreInstance.get());
@@ -201,14 +200,14 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
             }
 
             @Override
-            public Stream<LegendReferenceResolver> visit(Association association)
+            public Stream<Optional<LegendReferenceResolver>> visit(Association association)
             {
-                Stream<LegendReferenceResolver> milestonedPropertyReferences = toPropertyReferences(association.originalMilestonedProperties);
-                Stream<LegendReferenceResolver> propertyReferences = toPropertyReferences(association.properties);
-                Stream<LegendReferenceResolver> qualifiedPropertyReferences = toQualifiedPropertyReferences(association.qualifiedProperties);
-                Stream<LegendReferenceResolver> stereotypeReferences = toStereotypeReferences(association.stereotypes);
-                Stream<LegendReferenceResolver> taggedValueReferences = toTaggedValueReferences(association.taggedValues);
-                Stream<LegendReferenceResolver> coreReferences = Stream.empty();
+                Stream<Optional<LegendReferenceResolver>> milestonedPropertyReferences = toPropertyReferences(association.originalMilestonedProperties);
+                Stream<Optional<LegendReferenceResolver>> propertyReferences = toPropertyReferences(association.properties);
+                Stream<Optional<LegendReferenceResolver>> qualifiedPropertyReferences = toQualifiedPropertyReferences(association.qualifiedProperties);
+                Stream<Optional<LegendReferenceResolver>> stereotypeReferences = toStereotypeReferences(association.stereotypes);
+                Stream<Optional<LegendReferenceResolver>> taggedValueReferences = toTaggedValueReferences(association.taggedValues);
+                Stream<Optional<LegendReferenceResolver>> coreReferences = Stream.empty();
                 if (coreInstance.isPresent())
                 {
                     coreReferences = toReferences((org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association) coreInstance.get());
@@ -218,95 +217,95 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
             }
 
             @Override
-            public Stream<LegendReferenceResolver> visit(Enumeration enumeration)
+            public Stream<Optional<LegendReferenceResolver>> visit(Enumeration enumeration)
             {
-                Stream<LegendReferenceResolver> stereotypeReferences = toStereotypeReferences(enumeration.stereotypes);
-                Stream<LegendReferenceResolver> taggedValueReferences = toTaggedValueReferences(enumeration.taggedValues);
+                Stream<Optional<LegendReferenceResolver>> stereotypeReferences = toStereotypeReferences(enumeration.stereotypes);
+                Stream<Optional<LegendReferenceResolver>> taggedValueReferences = toTaggedValueReferences(enumeration.taggedValues);
                 return Stream.concat(stereotypeReferences, taggedValueReferences);
             }
         });
-        return pureReferences.collect(Collectors.toList());
+        return pureReferences;
     }
 
-    private Stream<LegendReferenceResolver> toPropertyReferences(List<Property> properties)
+    private Stream<Optional<LegendReferenceResolver>> toPropertyReferences(List<Property> properties)
     {
         return properties.stream().flatMap(this::toReferences);
     }
 
-    public static Stream<LegendReferenceResolver> toStereotypeReferences(List<StereotypePtr> stereotypePtrs)
+    public static Stream<Optional<LegendReferenceResolver>> toStereotypeReferences(List<StereotypePtr> stereotypePtrs)
     {
         return stereotypePtrs.stream().flatMap(PureLSPGrammarExtension::toReferences);
     }
 
-    public static Stream<LegendReferenceResolver> toTaggedValueReferences(List<TaggedValue> taggedValues)
+    public static Stream<Optional<LegendReferenceResolver>> toTaggedValueReferences(List<TaggedValue> taggedValues)
     {
         return taggedValues.stream().flatMap(PureLSPGrammarExtension::toReferences);
     }
 
-    private Stream<LegendReferenceResolver> toQualifiedPropertyReferences(List<QualifiedProperty> qualifiedProperties)
+    private Stream<Optional<LegendReferenceResolver>> toQualifiedPropertyReferences(List<QualifiedProperty> qualifiedProperties)
     {
         return qualifiedProperties.stream().flatMap(this::toReferences);
     }
 
-    private Stream<LegendReferenceResolver> toReferences(Property property)
+    private Stream<Optional<LegendReferenceResolver>> toReferences(Property property)
     {
-        LegendReferenceResolver propertyReference = LegendReferenceResolver.newReferenceResolver(property.propertyTypeSourceInformation, x -> x.resolvePackageableElement(property.type, property.propertyTypeSourceInformation));
-        Stream<LegendReferenceResolver> stereotypeReferences = toStereotypeReferences(property.stereotypes);
-        Stream<LegendReferenceResolver> taggedValueReferences = toTaggedValueReferences(property.taggedValues);
+        Optional<LegendReferenceResolver> propertyReference = LegendReferenceResolver.newReferenceResolver(property.propertyTypeSourceInformation, x -> x.resolvePackageableElement(property.type, property.propertyTypeSourceInformation));
+        Stream<Optional<LegendReferenceResolver>> stereotypeReferences = toStereotypeReferences(property.stereotypes);
+        Stream<Optional<LegendReferenceResolver>> taggedValueReferences = toTaggedValueReferences(property.taggedValues);
         return Stream.of(Stream.of(propertyReference), stereotypeReferences, taggedValueReferences)
                 .flatMap(java.util.function.Function.identity());
     }
 
-    private Stream<LegendReferenceResolver> toReferences(QualifiedProperty qualifiedProperty)
+    private Stream<Optional<LegendReferenceResolver>> toReferences(QualifiedProperty qualifiedProperty)
     {
-        Stream<LegendReferenceResolver> stereotypeReferences = toStereotypeReferences(qualifiedProperty.stereotypes);
-        Stream<LegendReferenceResolver> taggedValueReferences = toTaggedValueReferences(qualifiedProperty.taggedValues);
+        Stream<Optional<LegendReferenceResolver>> stereotypeReferences = toStereotypeReferences(qualifiedProperty.stereotypes);
+        Stream<Optional<LegendReferenceResolver>> taggedValueReferences = toTaggedValueReferences(qualifiedProperty.taggedValues);
         return Stream.concat(stereotypeReferences, taggedValueReferences);
     }
 
-    private static Stream<LegendReferenceResolver> toReferences(StereotypePtr stereotypePtr)
+    private static Stream<Optional<LegendReferenceResolver>> toReferences(StereotypePtr stereotypePtr)
     {
-        LegendReferenceResolver profileReference = LegendReferenceResolver.newReferenceResolver(stereotypePtr.profileSourceInformation, x -> x.resolveProfile(stereotypePtr.profile, stereotypePtr.profileSourceInformation));
-        LegendReferenceResolver stereotypeReference = LegendReferenceResolver.newReferenceResolver(stereotypePtr.sourceInformation, x -> x.resolveStereotype(stereotypePtr.profile, stereotypePtr.value, stereotypePtr.profileSourceInformation, stereotypePtr.sourceInformation));
+        Optional<LegendReferenceResolver> profileReference = LegendReferenceResolver.newReferenceResolver(stereotypePtr.profileSourceInformation, x -> x.resolveProfile(stereotypePtr.profile, stereotypePtr.profileSourceInformation));
+        Optional<LegendReferenceResolver> stereotypeReference = LegendReferenceResolver.newReferenceResolver(stereotypePtr.sourceInformation, x -> x.resolveStereotype(stereotypePtr.profile, stereotypePtr.value, stereotypePtr.profileSourceInformation, stereotypePtr.sourceInformation));
         return Stream.of(profileReference, stereotypeReference);
     }
 
-    private static Stream<LegendReferenceResolver> toReferences(TaggedValue taggedValue)
+    private static Stream<Optional<LegendReferenceResolver>> toReferences(TaggedValue taggedValue)
     {
-        LegendReferenceResolver profileReference = LegendReferenceResolver.newReferenceResolver(taggedValue.tag.profileSourceInformation, x -> x.resolveProfile(taggedValue.tag.profile, taggedValue.tag.profileSourceInformation));
-        LegendReferenceResolver tagReference = LegendReferenceResolver.newReferenceResolver(taggedValue.tag.sourceInformation, x -> x.resolveTag(taggedValue.tag.profile, taggedValue.tag.value, taggedValue.tag.profileSourceInformation, taggedValue.tag.sourceInformation));
+        Optional<LegendReferenceResolver> profileReference = LegendReferenceResolver.newReferenceResolver(taggedValue.tag.profileSourceInformation, x -> x.resolveProfile(taggedValue.tag.profile, taggedValue.tag.profileSourceInformation));
+        Optional<LegendReferenceResolver> tagReference = LegendReferenceResolver.newReferenceResolver(taggedValue.tag.sourceInformation, x -> x.resolveTag(taggedValue.tag.profile, taggedValue.tag.value, taggedValue.tag.profileSourceInformation, taggedValue.tag.sourceInformation));
         return Stream.of(profileReference, tagReference);
     }
 
-    private Stream<LegendReferenceResolver> toReferences(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class clazz)
+    private Stream<Optional<LegendReferenceResolver>> toReferences(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Class clazz)
     {
-        Stream<LegendReferenceResolver> constraintReferences = StreamSupport.stream(clazz._constraints().spliterator(), false)
+        Stream<Optional<LegendReferenceResolver>> constraintReferences = StreamSupport.stream(clazz._constraints().spliterator(), false)
                 .flatMap(this::toReferences);
         RichIterable<? extends CoreInstance> qualifiedProperties = clazz._qualifiedProperties();
-        Stream<LegendReferenceResolver> qualifiedPropertyReferences = StreamSupport.stream(qualifiedProperties.spliterator(), false)
+        Stream<Optional<LegendReferenceResolver>> qualifiedPropertyReferences = StreamSupport.stream(qualifiedProperties.spliterator(), false)
                 .flatMap(qualifiedProperty -> FUNCTION_EXPRESSION_NAVIGATOR.findReferences(Optional.ofNullable(qualifiedProperty)));
 
-        Stream<LegendReferenceResolver> superTypes = StreamSupport.stream(clazz._generalizations().spliterator(), false)
+        Stream<Optional<LegendReferenceResolver>> superTypes = StreamSupport.stream(clazz._generalizations().spliterator(), false)
                 .map(generalization -> LegendReferenceResolver.newReferenceResolver(generalization.getSourceInformation(), generalization._general()._rawType()));
 
         return Stream.concat(Stream.concat(constraintReferences, qualifiedPropertyReferences), superTypes);
     }
 
-    private Stream<LegendReferenceResolver> toReferences(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association association)
+    private Stream<Optional<LegendReferenceResolver>> toReferences(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Association association)
     {
         RichIterable<? extends CoreInstance> qualifiedProperties = association._qualifiedProperties();
         return StreamSupport.stream(qualifiedProperties.spliterator(), false)
                 .flatMap(qualifiedProperty -> FUNCTION_EXPRESSION_NAVIGATOR.findReferences(Optional.ofNullable(qualifiedProperty)));
     }
 
-    private Stream<LegendReferenceResolver> toReferences(Constraint constraint)
+    private Stream<Optional<LegendReferenceResolver>> toReferences(Constraint constraint)
     {
         if (constraint == null)
         {
             return Stream.empty();
         }
-        Stream<LegendReferenceResolver> functionDefinitionReference = FUNCTION_EXPRESSION_NAVIGATOR.findReferences(Optional.ofNullable(constraint._functionDefinition()));
-        Stream<LegendReferenceResolver> messageFunctionReference = FUNCTION_EXPRESSION_NAVIGATOR.findReferences(Optional.ofNullable(constraint._messageFunction()));
+        Stream<Optional<LegendReferenceResolver>> functionDefinitionReference = FUNCTION_EXPRESSION_NAVIGATOR.findReferences(Optional.ofNullable(constraint._functionDefinition()));
+        Stream<Optional<LegendReferenceResolver>> messageFunctionReference = FUNCTION_EXPRESSION_NAVIGATOR.findReferences(Optional.ofNullable(constraint._messageFunction()));
         return Stream.concat(functionDefinitionReference, messageFunctionReference);
     }
 
@@ -368,7 +367,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
             String path = _enum.getPath();
             _enum.values.forEach(value ->
             {
-                if (isValidSourceInfo(value.sourceInformation))
+                if (SourceInformationUtil.isValidSourceInfo(value.sourceInformation))
                 {
                     consumer.accept(LegendDeclaration.builder()
                             .withIdentifier(value.value)
@@ -399,7 +398,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
 
     private LegendDeclaration getDeclaration(Property property)
     {
-        if (!isValidSourceInfo(property.sourceInformation))
+        if (!SourceInformationUtil.isValidSourceInfo(property.sourceInformation))
         {
             LOGGER.warn("Invalid source information for property {}", property.name);
             return null;
@@ -414,7 +413,7 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
 
     private LegendDeclaration getDeclaration(QualifiedProperty property)
     {
-        if (!isValidSourceInfo(property.sourceInformation))
+        if (!SourceInformationUtil.isValidSourceInfo(property.sourceInformation))
         {
             LOGGER.warn("Invalid source information for qualified property {}", property.name);
             return null;

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarProvider.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarProvider.java
@@ -16,6 +16,7 @@
 
 package org.finos.legend.engine.ide.lsp.extension.mapping;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
@@ -26,11 +27,11 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation
 
 public interface MappingLSPGrammarProvider
 {
-    Stream<LegendReferenceResolver> getClassMappingReferences(ClassMapping mapping, GlobalState state);
+    Stream<Optional<LegendReferenceResolver>> getClassMappingReferences(ClassMapping mapping, GlobalState state);
 
-    Stream<LegendReferenceResolver> getAssociationMappingReferences(AssociationMapping associationMapping, GlobalState state);
+    Stream<Optional<LegendReferenceResolver>> getAssociationMappingReferences(AssociationMapping associationMapping, GlobalState state);
 
-    Stream<LegendReferenceResolver> getSetImplementationReferences(SetImplementation setImplementation);
+    Stream<Optional<LegendReferenceResolver>> getSetImplementationReferences(SetImplementation setImplementation);
 
-    Stream<LegendReferenceResolver> getPropertyMappingReferences(PropertyMapping propertyMapping);
+    Stream<Optional<LegendReferenceResolver>> getPropertyMappingReferences(PropertyMapping propertyMapping);
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/connection/TestConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/connection/TestConnectionLSPGrammarExtension.java
@@ -186,7 +186,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedClassReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_CONNECTION_DOC_ID, 3, 11, 3, 31))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 1, 0, 5, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 1, 0, 5, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_CONNECTION_DOC_ID, TextPosition.newPosition(2, 2), null, "Outside of mappedClassReference-able element should yield nothing");
@@ -315,7 +315,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedMappingReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 5, 7, 5, 38))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(4, 2), null, "Outside of mappedMappingReference-able element should yield nothing");
@@ -327,28 +327,28 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedStoreReference1 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 9, 7, 9, 30))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID_1, 1, 0, 10, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID_1, 1, 0, 10, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(9, 20), mappedStoreReference1, "Within the store name has been mapped, referring to store definition");
 
         LegendReference mappedConnectionReference1 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 11, 25, 11, 59))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CONNECTION_DOC_ID_1, 1, 0, 12, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CONNECTION_DOC_ID_1, 1, 0, 12, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(11, 30), mappedConnectionReference1, "Within the connection name has been mapped, referring to connection definition");
 
         LegendReference mappedStoreReference2 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 13, 7, 13, 30))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID_2, 1, 0, 9, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID_2, 1, 0, 9, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(13, 20), mappedStoreReference2, "Within the store name has been mapped, referring to store definition");
 
         LegendReference mappedConnectionReference2 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 15, 25, 15, 59))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CONNECTION_DOC_ID_2, 1, 0, 12, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CONNECTION_DOC_ID_2, 1, 0, 12, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(15, 38), mappedConnectionReference2, "Within the connection name has been mapped, referring to connection definition");
@@ -430,7 +430,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedMappingReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 5, 7, 5, 38))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(4, 2), null, "Outside of mappedMappingReference-able element should yield nothing");
@@ -442,7 +442,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedClassReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 15, 26, 15, 50))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 1, 0, 6, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 1, 0, 6, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(15, 46), mappedClassReference, "Within the class name has been mapped, referring to class definition");
@@ -524,7 +524,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedMappingReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 5, 7, 5, 38))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(4, 2), null, "Outside of mappedMappingReference-able element should yield nothing");
@@ -536,7 +536,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedClassReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 15, 26, 15, 50))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 1, 0, 6, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 1, 0, 6, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(15, 46), mappedClassReference, "Within the class name has been mapped, referring to class definition");
@@ -644,7 +644,7 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedMappingReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 5, 7, 5, 38))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(4, 2), null, "Outside of mappedMappingReference-able element should yield nothing");
@@ -656,21 +656,21 @@ public class TestConnectionLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedConnectionReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 9, 7, 9, 41))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CONNECTION_DOC_ID, 1, 0, 12, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CONNECTION_DOC_ID, 1, 0, 12, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(9, 30), mappedConnectionReference, "Within the connection name has been mapped, referring to connection definition");
 
         LegendReference mappedStoreReference1 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 11, 11, 11, 34))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID_1, 1, 0, 13, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID_1, 1, 0, 13, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(11, 20), mappedStoreReference1, "Within the store name has been mapped, referring to store definition");
 
         LegendReference mappedStoreReference2 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 12, 11, 12, 30))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID_2, 1, 0, 9, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID_2, 1, 0, 9, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(12, 20), mappedStoreReference2, "Within the store name has been mapped, referring to store definition");

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/core/TestPureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/core/TestPureLSPGrammarExtension.java
@@ -611,14 +611,14 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
 
         LegendReference petReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(docId, 9, 35, 9, 54))
-                .withReferencedLocation(TextLocation.newTextSource(docId, 5, 0, 8, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(docId, 5, 0, 8, 0))
                 .build();
 
         testReferenceLookup(codeFiles, docId, TextPosition.newPosition(9, 50), petReference, "Supertype linked to class");
 
         LegendReference mammalReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(docId, 9, 57, 9, 79))
-                .withReferencedLocation(TextLocation.newTextSource(docId, 1, 0, 4, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(docId, 1, 0, 4, 0))
                 .build();
 
         testReferenceLookup(codeFiles, docId, TextPosition.newPosition(9, 65), mammalReference, "Supertype linked to class");
@@ -683,25 +683,25 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
 
         LegendReference mappedProfileReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID3, 1, 8, 1, 35))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_PROFILE_DOC_ID, 1, 0, 5, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_PROFILE_DOC_ID, 1, 0, 5, 0))
                 .build();
         testReferenceLookup(codeFiles, TEST_CLASS_DOC_ID3, TextPosition.newPosition(1, 30), mappedProfileReference, "Within the profile name has been mapped, referring to profile");
 
         LegendReference mappedProfileReference2 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID3, 1, 50, 1, 77))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_PROFILE_DOC_ID, 1, 0, 5, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_PROFILE_DOC_ID, 1, 0, 5, 0))
                 .build();
         testReferenceLookup(codeFiles, TEST_CLASS_DOC_ID3, TextPosition.newPosition(1, 70), mappedProfileReference2, "Within the profile name has been mapped, referring to profile");
 
         LegendReference mappedPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID3, 6, 13, 6, 35))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID2, 1, 0, 5, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID2, 1, 0, 5, 0))
                 .build();
         testReferenceLookup(codeFiles, TEST_CLASS_DOC_ID3, TextPosition.newPosition(6, 30), mappedPropertyReference, "Within the property has been mapped, referring to property");
 
         LegendReference mappedPropertyReference2 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID3, 7, 11, 7, 34))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_ENUMERATION_DOC_ID, 1, 0, 5, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_ENUMERATION_DOC_ID, 1, 0, 5, 0))
                 .build();
         testReferenceLookup(codeFiles, TEST_CLASS_DOC_ID3, TextPosition.newPosition(7, 30), mappedPropertyReference2, "Within the property has been mapped, referring to property");
     }
@@ -739,7 +739,7 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
 
         LegendReference mappedPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 5, 11, 5, 12))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 3, 2, 3, 15))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 3, 2, 3, 15))
                 .build();
         testReferenceLookup(codeFiles, TEST_FUNCTION_DOC_ID, TextPosition.newPosition(5, 12), mappedPropertyReference, "Within the property name has been mapped, referring to property");
     }
@@ -806,7 +806,7 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
 
         LegendReference mappedPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 6, 10, 6, 11))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 3, 2, 3, 16))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 3, 2, 3, 16))
                 .build();
         testReferenceLookup(codeFiles, TEST_FUNCTION_DOC_ID, TextPosition.newPosition(6, 10), mappedPropertyReference, "Within the property name has been mapped, referring to property");
     }
@@ -953,13 +953,13 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
         MutableMap<String, String> codeFiles = this.getCodeFilesThatParseCompile();
         LegendReference mappedClassPropertyInLambdaReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 5, 41, 5, 45))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::TestClass5", 5, 2, 5, 39))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::TestClass5", 5, 2, 5, 39))
                 .build();
         testReferenceLookup(codeFiles, "vscodelsp::test::TestClass3", TextPosition.newPosition(5, 42), mappedClassPropertyInLambdaReference, "Within the class property has been mapped, referring to class property definition");
 
         LegendReference mappedQualifiedPropertyLambdaPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 20, 18, 20, 26))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::TestClass5", 6, 2, 6, 29))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::TestClass5", 6, 2, 6, 29))
                 .build();
         testReferenceLookup(codeFiles, "vscodelsp::test::TestClass3", TextPosition.newPosition(20, 20), mappedQualifiedPropertyLambdaPropertyReference, "Within the property has been mapped, referring to property definition");
     }
@@ -971,37 +971,37 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
         MutableMap<String, String> codeFiles = this.getCodeFilesThatParseCompile();
         LegendReference mappedClassReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 3, 16, 3, 19))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 1, 0, 21, 0))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 1, 0, 21, 0))
                 .build();
         testReferenceLookup(codeFiles, "vscodelsp::test::TestClass3", TextPosition.newPosition(3, 17), mappedClassReference, "Within the class name has been mapped, referring to class definition");
 
         LegendReference mappedClassReference2 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 5, 7, 5, 33))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 1, 0, 21, 0))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 1, 0, 21, 0))
                 .build();
         testReferenceLookup(codeFiles, "vscodelsp::test::TestClass3", TextPosition.newPosition(5, 17), mappedClassReference2, "Within the class name has been mapped, referring to class definition");
 
         LegendReference mappedNestedClassPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::TestClass3", 5, 47, 5, 48))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::TestClass7", 3, 2, 3, 16))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::TestClass7", 3, 2, 3, 16))
                 .build();
         testReferenceLookup(codeFiles, "vscodelsp::test::TestClass3", TextPosition.newPosition(5, 47), mappedNestedClassPropertyReference, "Within the nested property name has been mapped, referring to property definition");
 
         LegendReference mappedReturnTypeReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::TestClass7", 18, 4, 18, 30))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::TestClass4", 3, 2, 3, 16))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::TestClass4", 3, 2, 3, 16))
                 .build();
         testReferenceLookup(codeFiles, "vscodelsp::test::TestClass7", TextPosition.newPosition(18, 25), mappedReturnTypeReference, "Within the return type has been mapped, referring to class definition");
 
         LegendReference mappedEnumReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::TestClass8", 7, 4, 7, 26))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::MyEnum", 1, 0, 6, 0))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::MyEnum", 1, 0, 6, 0))
                 .build();
         testReferenceLookup(codeFiles, "vscodelsp::test::TestClass8", TextPosition.newPosition(7, 25), mappedEnumReference, "Within the enum has been mapped, referring to enum definition");
 
         LegendReference mappedEnumValueReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::TestClass8", 7, 28, 7, 32))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::MyEnum", 3, 2, 3, 6))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::MyEnum", 3, 2, 3, 6))
                 .build();
         testReferenceLookup(codeFiles, "vscodelsp::test::TestClass8", TextPosition.newPosition(7, 29), mappedEnumValueReference, "Within the enum value has been mapped, referring to enum value definition");
     }
@@ -1040,25 +1040,25 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
 
         LegendReference mappedClassReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 3, 2, 3, 29))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 1, 0, 6, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 1, 0, 6, 0))
                 .build();
         testReferenceLookup(codeFiles, TEST_FUNCTION_DOC_ID, TextPosition.newPosition(3, 25), mappedClassReference, "Within the class name has been mapped, referring to class definition");
 
         LegendReference mappedParameterReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 3, 36, 3, 47))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 1, 33, 1, 53))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 1, 33, 1, 53))
                 .build();
         testReferenceLookup(codeFiles, TEST_FUNCTION_DOC_ID, TextPosition.newPosition(3, 40), mappedParameterReference, "Within the parameter name has been mapped, referring to parameter");
 
         LegendReference mappedPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 5, 11, 5, 12))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 3, 2, 3, 14))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 3, 2, 3, 14))
                 .build();
         testReferenceLookup(codeFiles, TEST_FUNCTION_DOC_ID, TextPosition.newPosition(5, 12), mappedPropertyReference, "Within the property name has been mapped, referring to property");
 
         LegendReference mappedLambdaVariableReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 5, 9, 5, 9))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 5, 6, 5, 6))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 5, 6, 5, 6))
                 .build();
         testReferenceLookup(codeFiles, TEST_FUNCTION_DOC_ID, TextPosition.newPosition(5, 9), mappedLambdaVariableReference, "Within the lambda variable has been mapped, referring to lambda variable");
     }
@@ -1091,7 +1091,7 @@ public class TestPureLSPGrammarExtension extends AbstractLSPGrammarExtensionTest
 
         LegendReference mappedTablePropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_FUNCTION_DOC_ID, 3, 54, 3, 55))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_DATABASE_DOC_ID, 5, 5, 5, 25))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_DATABASE_DOC_ID, 5, 5, 5, 25))
                 .build();
         testReferenceLookup(codeFiles, TEST_FUNCTION_DOC_ID, TextPosition.newPosition(3, 55), mappedTablePropertyReference, "Within the property name has been mapped, referring to property definition");
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/mapping/TestMappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/mapping/TestMappingLSPGrammarExtension.java
@@ -176,7 +176,7 @@ public class TestMappingLSPGrammarExtension extends AbstractLSPGrammarExtensionT
 
         LegendReference targetMappedClassReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",3,  3, 3, 27))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::Employee", 1, 0, 6, 0))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::Employee", 1, 0, 6, 0))
                 .build();
 
         testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(2, 1), null, "Outside of targetMappedClassReference-able element should yield nothing");
@@ -189,14 +189,14 @@ public class TestMappingLSPGrammarExtension extends AbstractLSPGrammarExtensionT
 
         LegendReference srcMappedClassReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",5,  11, 5, 38))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeSrc", 1, 0, 6, 0))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeSrc", 1, 0, 6, 0))
                 .build();
 
         testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(5, 12), srcMappedClassReference, "Source class reference");
 
         LegendReference propertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",6,  6, 6, 13))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::Employee", 4, 4, 4, 22))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::Employee", 4, 4, 4, 22))
                 .build();
 
         testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(6, 10), propertyReference, "Property mapped reference");
@@ -252,7 +252,7 @@ public class TestMappingLSPGrammarExtension extends AbstractLSPGrammarExtensionT
 
         LegendReference mappedIncludedMappingReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID_1, 3, 3, 3, 50))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID_2, 1, 0, 8, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID_2, 1, 0, 8, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_MAPPING_DOC_ID_1, TextPosition.newPosition(2, 2), null, "Outside of mappedIncludedMappingReference-able element should yield nothing");
@@ -264,7 +264,7 @@ public class TestMappingLSPGrammarExtension extends AbstractLSPGrammarExtensionT
 
         LegendReference mappedClassPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID_1, 8, 23, 8, 24))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 4, 3, 4, 16))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_CLASS_DOC_ID, 4, 3, 4, 16))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_MAPPING_DOC_ID_1, TextPosition.newPosition(8, 24), mappedClassPropertyReference, "Within the class property name has been mapped, referring to class property definition");

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/relational/TestRelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/relational/TestRelationalLSPGrammarExtension.java
@@ -75,11 +75,9 @@ public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensi
                                         .withChild(LegendDeclaration.builder().withIdentifier("NAME").withClassifier(M2RelationalPaths.Column).withLocation(DOC_ID_FOR_TEXT,15, 12, 15, 28).build())
                                         .build())
                                 .build())
-                        .withChild(LegendDeclaration.builder().withIdentifier("default").withClassifier(M2RelationalPaths.Schema).withLocation(DOC_ID_FOR_TEXT,3, 0, 18, 0)
-                                .withChild(LegendDeclaration.builder().withIdentifier("T1").withClassifier(M2RelationalPaths.Table).withLocation(DOC_ID_FOR_TEXT,5, 4, 8, 4)
-                                        .withChild(LegendDeclaration.builder().withIdentifier("ID").withClassifier(M2RelationalPaths.Column).withLocation(DOC_ID_FOR_TEXT,7, 8, 7, 13).build())
-                                        .withChild(LegendDeclaration.builder().withIdentifier("NAME").withClassifier(M2RelationalPaths.Column).withLocation(DOC_ID_FOR_TEXT,7, 16, 7, 32).build())
-                                        .build())
+                        .withChild(LegendDeclaration.builder().withIdentifier("T1").withClassifier(M2RelationalPaths.Table).withLocation(DOC_ID_FOR_TEXT,5, 4, 8, 4)
+                                .withChild(LegendDeclaration.builder().withIdentifier("ID").withClassifier(M2RelationalPaths.Column).withLocation(DOC_ID_FOR_TEXT,7, 8, 7, 13).build())
+                                .withChild(LegendDeclaration.builder().withIdentifier("NAME").withClassifier(M2RelationalPaths.Column).withLocation(DOC_ID_FOR_TEXT,7, 16, 7, 32).build())
                                 .build())
                         .build()
         );
@@ -365,14 +363,14 @@ public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mainTableReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",5,  52, 5, 64))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeDatabase", 3, 3, 3, 96))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeDatabase", 3, 3, 3, 96))
                 .build();
 
         testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(5, 60), mainTableReference, "main table reference");
 
         LegendReference columnReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeMapping",6,   17, 6, 73))
-                .withReferencedLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeDatabase", 3, 43, 3, 55))
+                .withDeclarationLocation(TextLocation.newTextSource("vscodelsp::test::EmployeeDatabase", 3, 43, 3, 55))
                 .build();
 
         testReferenceLookup(codeFiles, "vscodelsp::test::EmployeeMapping", TextPosition.newPosition(6, 21), columnReference, "Property mapped reference");
@@ -461,7 +459,7 @@ public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedMappingReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 5, 7, 5, 38))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(4, 2), null, "Outside of mappedMappingReference-able element should yield nothing");
@@ -473,14 +471,14 @@ public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedStoreReference1 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 9, 7, 9, 30))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID, 1, 0, 10, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID, 1, 0, 10, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(9, 20), mappedStoreReference1, "Within the store name has been mapped, referring to store definition");
 
         LegendReference mappedStoreReference2 = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 15, 26, 15, 49))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID, 1, 0, 10, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_STORE_DOC_ID, 1, 0, 10, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_RUNTIME_DOC_ID, TextPosition.newPosition(15, 31), mappedStoreReference2, "Within the store name has been mapped, referring to store definition");
@@ -568,7 +566,7 @@ public class TestRelationalLSPGrammarExtension extends AbstractLSPGrammarExtensi
 
         LegendReference mappedAssociationReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 25, 11, 25, 26))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_ASSOCIATION_DOC_ID, 3, 3, 3, 48))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_ASSOCIATION_DOC_ID, 3, 3, 3, 48))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_MAPPING_DOC_ID, TextPosition.newPosition(24, 2), null, "Outside of mappedAssociationReference-able element should yield nothing");

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
@@ -357,14 +357,14 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
 
         LegendReference mappedMappingReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_SERVICE_DOC_ID, 8, 18, 8, 49))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_MAPPING_DOC_ID, 1, 0, 9, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_SERVICE_DOC_ID, TextPosition.newPosition(8, 21), mappedMappingReference, "Within the mapping name has been mapped, referring to mapping definition");
 
         LegendReference mappedRuntimeReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(TEST_SERVICE_DOC_ID, 9, 18, 9, 43))
-                .withReferencedLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 1, 0, 18, 0))
+                .withDeclarationLocation(TextLocation.newTextSource(TEST_RUNTIME_DOC_ID, 1, 0, 18, 0))
                 .build();
 
         testReferenceLookup(codeFiles, TEST_SERVICE_DOC_ID, TextPosition.newPosition(9, 41), mappedRuntimeReference, "Within the runtime name has been mapped, referring to runtime definition");
@@ -376,7 +376,7 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         MutableMap<String, String> codeFiles = this.getCodeFilesForPostValidations();
         LegendReference mappedClassPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("test::service", 9, 52, 9, 56))
-                .withReferencedLocation(TextLocation.newTextSource("test::class", 3, 4, 3, 20))
+                .withDeclarationLocation(TextLocation.newTextSource("test::class", 3, 4, 3, 20))
                 .build();
 
         testReferenceLookup(codeFiles, "test::service", TextPosition.newPosition(9, 54), mappedClassPropertyReference, "Within the class property has been mapped, referring to class property definition");
@@ -389,7 +389,7 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         MutableMap<String, String> codeFiles = this.getCodeFilesForPostValidations();
         LegendReference mappedClassPropertyReference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource("test::service", 19, 68, 19, 71))
-                .withReferencedLocation(TextLocation.newTextSource("test::service", 19, 64, 19, 66))
+                .withDeclarationLocation(TextLocation.newTextSource("test::service", 19, 64, 19, 66))
                 .build();
 
         testReferenceLookup(codeFiles, "test::service", TextPosition.newPosition(19, 70), mappedClassPropertyReference, "Within the lambda variable has been mapped, referring to lambda variable definition");

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
@@ -130,12 +130,12 @@ public interface LegendLSPGrammarExtension extends LegendLSPExtension
     }
 
     /**
-     * Provides access to all references available on the section state.  Given this can be computing expensive, depending on the
+     * Provides access to all references available on the section state.  Given that this can be computationally expensive, depending on the
      * number of elements on the section, the method returns a Stream to allow further processing by the caller without the need
      * to bring all these into memory.
      *
      * @param sectionState grammar section state
-     * @return all a stream of all references existing on the given section state
+     * @return a stream of all references existing in the given section state
      */
     default Stream<LegendReference> getLegendReferences(SectionState sectionState)
     {

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
@@ -54,6 +55,18 @@ public interface LegendLSPGrammarExtension extends LegendLSPExtension
     default Iterable<? extends LegendDeclaration> getDeclarations(SectionState section)
     {
         return Collections.emptyList();
+    }
+
+    /**
+     * Return the Legend declaration for the given section at the given position, if one exists.
+     *
+     * @param section grammar section state
+     * @param position the position to get the declaration
+     * @return Legend declaration at given position
+     */
+    default Optional<LegendDeclaration> getDeclaration(SectionState section, TextPosition position)
+    {
+        return Optional.empty();
     }
 
     /**
@@ -114,6 +127,19 @@ public interface LegendLSPGrammarExtension extends LegendLSPExtension
     default Optional<LegendReference> getLegendReference(SectionState sectionState, TextPosition textPosition)
     {
         return Optional.empty();
+    }
+
+    /**
+     * Provides access to all references available on the section state.  Given this can be computing expensive, depending on the
+     * number of elements on the section, the method returns a Stream to allow further processing by the caller without the need
+     * to bring all these into memory.
+     *
+     * @param sectionState grammar section state
+     * @return all a stream of all references existing on the given section state
+     */
+    default Stream<LegendReference> getLegendReferences(SectionState sectionState)
+    {
+        return Stream.empty();
     }
     
     /**

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/reference/LegendReference.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/reference/LegendReference.java
@@ -21,26 +21,26 @@ import org.finos.legend.engine.ide.lsp.extension.text.LegendTextObject;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 
 /**
- * Legend reference. This track the location where a pointer to another element exits, and the referenced element's location.
+ * Legend reference. This track the location where a pointer to another element exits, and the referenced element's (declaration) location.
  * This allows navigation from the given reference to the referenced location.
  */
 public class LegendReference extends LegendTextObject
 {
-    private final TextLocation referencedLocation;
+    private final TextLocation declarationLocation;
 
-    private LegendReference(TextLocation referenceLocation, TextLocation coreReferenceLocation, TextLocation referencedLocation)
+    private LegendReference(TextLocation referenceLocation, TextLocation coreReferenceLocation, TextLocation declarationLocation)
     {
         super(referenceLocation, coreReferenceLocation);
-        this.referencedLocation = Objects.requireNonNull(referencedLocation, "referenced location is required");
+        this.declarationLocation = Objects.requireNonNull(declarationLocation, "declaration location is required");
     }
 
     /**
-     * The referenced element location.
-     * @return the location of the element been referenced by this reference
+     * The element declaration location.
+     * @return the location of the declaration this reference links to
      */
-    public TextLocation getReferencedLocation()
+    public TextLocation getDeclarationLocation()
     {
-        return referencedLocation;
+        return declarationLocation;
     }
 
     public static Builder builder()
@@ -64,13 +64,13 @@ public class LegendReference extends LegendTextObject
         LegendReference that = (LegendReference) other;
         return getLocation().equals(that.getLocation()) &&
                 Objects.equals(getCoreLocation(), that.getCoreLocation()) &&
-                this.referencedLocation.equals(that.referencedLocation);
+                this.declarationLocation.equals(that.declarationLocation);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(this.getLocation(), this.getCoreLocation(), this.referencedLocation);
+        return Objects.hash(this.getLocation(), this.getCoreLocation(), this.declarationLocation);
     }
 
     @Override
@@ -86,7 +86,7 @@ public class LegendReference extends LegendTextObject
         {
             builder.append(" coreLocation=").append(getCoreLocation());
         }
-        builder.append(" referencedLocation=").append(this.referencedLocation);
+        builder.append(" declarationLocation=").append(this.declarationLocation);
         return builder.append("}");
     }
 
@@ -95,7 +95,7 @@ public class LegendReference extends LegendTextObject
      */
     public static class Builder extends AbstractBuilder<Builder>
     {
-        private TextLocation referencedLocation;
+        private TextLocation declarationLocation;
 
         private Builder()
         {
@@ -109,20 +109,20 @@ public class LegendReference extends LegendTextObject
         }
 
         /**
-         * Location of the referenced element
+         * Location of the declaration been referenced
          *
-         * @param referencedLocation referenced element's location
-         * @return the current builder with the new referenced location set
+         * @param declarationLocation declaration element's location
+         * @return the current builder with the new declaration location set
          */
-        public Builder withReferencedLocation(TextLocation referencedLocation)
+        public Builder withDeclarationLocation(TextLocation declarationLocation)
         {
-            this.referencedLocation = referencedLocation;
+            this.declarationLocation = declarationLocation;
             return this;
         }
 
         public LegendReference build()
         {
-            return new LegendReference(this.getLocation(), this.getCoreLocation(), this.referencedLocation);
+            return new LegendReference(this.getLocation(), this.getCoreLocation(), this.declarationLocation);
         }
     }
 }

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/reference/LegendReference.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/reference/LegendReference.java
@@ -21,7 +21,7 @@ import org.finos.legend.engine.ide.lsp.extension.text.LegendTextObject;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 
 /**
- * Legend reference. This track the location where a pointer to another element exits, and the referenced element's (declaration) location.
+ * Legend reference. This tracks the location where a reference to another element exists and the referenced element's declaration location.
  * This allows navigation from the given reference to the referenced location.
  */
 public class LegendReference extends LegendTextObject

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageServer.java
@@ -868,6 +868,7 @@ public class LegendLanguageServer implements LegendLanguageServerContract
         capabilities.setCodeLensProvider(getCodeLensOptions());
         capabilities.setExecuteCommandProvider(getExecuteCommandOptions());
         capabilities.setDefinitionProvider(true);
+        capabilities.setReferencesProvider(true);
         capabilities.setDiagnosticProvider(getDiagnosticRegistrationOptions());
         capabilities.setDocumentSymbolProvider(true);
         capabilities.setWorkspaceSymbolProvider(true);

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
@@ -607,11 +607,11 @@ public class LegendTextDocumentService implements TextDocumentService
     /**
      * Compute the references of a given declaration.
      * <p>
-     * The implementation first look through the declaration at the interested position,
-     * and then compute what navigation reference links to that location.
+     * The implementation first looks through the declaration at the given position,
+     * and then computes references that link to that declaration.
      *
-     * @param params request params, including the location of the declaration to look for references
-     * @return the list of reference for the declaration at given position
+     * @param params request params, including the location of the declaration to look for references to
+     * @return the list of references to the declaration at the given position
      */
     @Override
     public CompletableFuture<List<? extends Location>> references(ReferenceParams params)

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
@@ -47,6 +47,7 @@ import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RelatedFullDocumentDiagnosticReport;
 import org.eclipse.lsp4j.SemanticTokens;
 import org.eclipse.lsp4j.SemanticTokensRangeParams;
@@ -68,6 +69,7 @@ import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
 import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.GrammarSection;
+import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.server.LegendServerGlobalState.LegendServerDocumentState;
@@ -588,7 +590,7 @@ public class LegendTextDocumentService implements TextDocumentService
 
             return Either.forRight(reference.map(x ->
                             {
-                                TextLocation referencedLocation = x.getReferencedLocation();
+                                TextLocation referencedLocation = x.getDeclarationLocation();
                                 Range range = LegendToLSPUtilities.toRange(referencedLocation.getTextInterval());
                                 return List.of(new LocationLink(
                                         referencedLocation.getDocumentId(),
@@ -602,4 +604,105 @@ public class LegendTextDocumentService implements TextDocumentService
         });
     }
 
+    /**
+     * Compute the references of a given declaration.
+     * <p>
+     * The implementation first look through the declaration at the interested position,
+     * and then compute what navigation reference links to that location.
+     *
+     * @param params request params, including the location of the declaration to look for references
+     * @return the list of reference for the declaration at given position
+     */
+    @Override
+    public CompletableFuture<List<? extends Location>> references(ReferenceParams params)
+    {
+        return this.server.supplyPossiblyAsync(() ->
+        {
+            String uri = params.getTextDocument().getUri();
+            TextPosition textPosition = TextPosition.newPosition(params.getPosition().getLine(), params.getPosition().getCharacter());
+
+            LegendServerDocumentState currDocumentState = this.server.getGlobalState().getDocumentState(uri);
+            if (currDocumentState == null)
+            {
+                LOGGER.warn("No state for {}: cannot go to definition", uri);
+                return List.of();
+            }
+
+            SectionState currSectionState = currDocumentState.getSectionStateAtLine(textPosition.getLine());
+
+            if (currSectionState == null)
+            {
+                LOGGER.warn("Cannot find section state for line {} of {}: cannot go to definition", textPosition.getLine(), uri);
+                return List.of();
+            }
+
+            LegendLSPGrammarExtension currExtension = currSectionState.getExtension();
+
+            if (currExtension == null)
+            {
+                LOGGER.warn("No extension available for section state on line {} of {}: cannot go to definition", textPosition.getLine(), uri);
+                return List.of();
+            }
+
+            TextLocation location = TextLocation.newTextSource(uri, TextInterval.newInterval(textPosition, textPosition));
+
+            // try to find the declaration that we want to find references/usage
+            Optional<? extends LegendDeclaration> maybeDeclarationToFindReferences = currExtension.getDeclaration(currSectionState, textPosition);
+
+            if (maybeDeclarationToFindReferences.isEmpty())
+            {
+                return List.of();
+            }
+
+            LegendDeclaration declarationToFindReferences = maybeDeclarationToFindReferences.get();
+
+            // narrow down through the children, in case the request is for one of these
+            boolean cont = declarationToFindReferences.hasChildren();
+            while (cont)
+            {
+                // flag to stop looping
+                cont = false;
+                for (LegendDeclaration child : declarationToFindReferences.getChildren())
+                {
+                    // check if child is a better candidate for the interested declaration to look for references
+                    if (child.getLocation().subsumes(location))
+                    {
+                        // update declaration for reference lookups
+                        declarationToFindReferences = child;
+                        // narrow down even further if the new declaration has children
+                        cont = declarationToFindReferences.hasChildren();
+                        break;
+                    }
+                }
+            }
+
+            TextLocation locationToLookForReferences = declarationToFindReferences.getLocation();
+            List<Location> references = new ArrayList<>();
+
+            this.server.getGlobalState()
+                    .forEachDocumentState(documentState ->
+                            documentState.forEachSectionState(sectionState ->
+                                    {
+                                        LegendLSPGrammarExtension extension = sectionState.getExtension();
+                                        if (extension != null)
+                                        {
+                                            extension.getLegendReferences(sectionState)
+                                                    // we look into the referenced location to match the declaration we care
+                                                    .filter(ref -> locationToLookForReferences.equals(ref.getDeclarationLocation()))
+                                                    .map(ref -> new Location(ref.getLocation().getDocumentId(), LegendToLSPUtilities.toRange(ref.getLocation().getTextInterval())))
+                                                    .forEach(references::add);
+                                        }
+                                    }
+                            )
+                    );
+
+
+            if (params.getContext().isIncludeDeclaration())
+            {
+                references.add(new Location(locationToLookForReferences.getDocumentId(), LegendToLSPUtilities.toRange(locationToLookForReferences.getTextInterval())));
+            }
+
+            return references;
+        });
+    }
 }

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/TestLegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/TestLegendTextDocumentService.java
@@ -312,7 +312,7 @@ public class TestLegendTextDocumentService
 
         LegendReference reference = LegendReference.builder()
                 .withLocation(TextLocation.newTextSource(uri, 8, 23, 8, 55))
-                .withReferencedLocation(TextLocation.newTextSource(uri, 11, 1, 14, 2))
+                .withDeclarationLocation(TextLocation.newTextSource(uri, 11, 1, 14, 2))
                 .build();
 
         LegendLSPGrammarExtension extWithKeywords = newExtension(


### PR DESCRIPTION
This PR add support for reference LSP API.

The reference API implementation leverage the reference resolvers leveraged for navigation (goTo), doing a reverse lookup to find all the navigations that reached a given declaration.  The lookup can be expensive since it goes thru all the references in the project, hence the move to Stream rather than list to better manage the number of items in memory that we anyways will discard as they are no in-scope for the user request (ie - reference that are not for the given delcaration).  

Given source information can be missed or be incorrect, there is a switch to Optional on all the reference resolver methods, allowing to handle centrally if a source information is invalid, and preventing exceptions when computing either goTo or references.

Below how the feature behave on VSCode

![find reference](https://github.com/finos/legend-engine-ide-lsp/assets/24432403/e442e02f-bef9-4857-ac23-bd8bc9b3b5ee)

 