### PR TITLE
Ensure multi-service execution key is a variable user can input

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
@@ -57,6 +57,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.ExecutionPla
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Enumeration;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.Variable;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.shared.core.identity.Identity;
@@ -89,7 +90,7 @@ public interface FunctionExecutionSupport
     {
         List<PackageableElement> elements = compileResult.getPureModelContextData().getElements();
         Map<String, LegendInputParameter> parameters = Maps.mutable.empty();
-        List<Variable> funcParameters = executionSupport.getLambda(element).parameters;
+        List<Variable> funcParameters = executionSupport.getParameters(element);
         if (funcParameters != null && !funcParameters.isEmpty())
         {
             funcParameters.forEach(p ->
@@ -107,6 +108,8 @@ public interface FunctionExecutionSupport
         }
         consumer.accept(EXECUTE_COMMAND_ID, EXECUTE_COMMAND_TITLE, element.sourceInformation, Collections.emptyMap(), parameters, LegendCommandType.CLIENT);
     }
+
+    List<Variable> getParameters(PackageableElement element);
 
     static Iterable<? extends LegendExecutionResult> executeFunction(FunctionExecutionSupport executionSupport, SectionState section, String entityPath, Map<String, Object> inputParameters)
     {
@@ -293,16 +296,16 @@ public interface FunctionExecutionSupport
 
     class LegendFunctionInputParameter extends LegendInputParameter
     {
-        private final Variable variable;
+        private final LegendVariable variable;
         private final PackageableElement element;
 
         private LegendFunctionInputParameter(Variable variable, PackageableElement element)
         {
-            this.variable = variable;
+            this.variable = LegendVariable.create(variable);
             this.element = element;
         }
 
-        public Variable getVariable()
+        public LegendVariable getVariable()
         {
             return this.variable;
         }
@@ -320,6 +323,40 @@ public interface FunctionExecutionSupport
         public static LegendFunctionInputParameter newFunctionParameter(Variable variable, PackageableElement element)
         {
             return new LegendFunctionInputParameter(variable, element);
+        }
+    }
+
+    class LegendVariable
+    {
+        private final String name;
+        private final Multiplicity multiplicity;
+        private final String _class;
+
+        private LegendVariable(String name, Multiplicity multiplicity, String _class)
+        {
+            this.name = name;
+            this.multiplicity = multiplicity;
+            this._class = _class;
+        }
+
+        public static LegendVariable create(Variable variable)
+        {
+            return new LegendVariable(variable.name, variable.multiplicity, variable._class.path);
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public Multiplicity getMultiplicity()
+        {
+            return multiplicity;
+        }
+
+        public String get_class()
+        {
+            return _class;
         }
     }
 

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PureLSPGrammarExtension.java
@@ -84,6 +84,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.function.FunctionTestSuite;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.function.StoreTestData;
 import org.finos.legend.engine.protocol.pure.v1.model.test.TestSuite;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.Variable;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.repl.autocomplete.Completer;
@@ -560,5 +561,12 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
         SingleExecutionPlan executionPlan = this.getExecutionPlan(element, this.getLambda(element), pureModel, Map.of());
         MutableList<LegendExecutionResult> results = Lists.mutable.empty();
         FunctionExecutionSupport.executePlan(this, "memory", -1, executionPlan, null, element.getPath(), Map.of(), results);
+    }
+
+    @Override
+    public List<Variable> getParameters(PackageableElement element)
+    {
+        Function function = (Function) element;
+        return function.parameters;
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +72,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextDa
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.Multiplicity;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.Runtime;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Execution;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.KeyedExecutionParameter;
@@ -80,6 +82,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.ServiceTestSuite;
 import org.finos.legend.engine.protocol.pure.v1.model.test.TestSuite;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.Variable;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
 import org.finos.legend.engine.test.runner.service.RichServiceTestResult;
@@ -536,5 +539,24 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
     {
         return state.findGrammarExtensionThatImplements(RuntimeLSPGrammarExtension.class)
                 .flatMap(x -> x.getRuntimeReferences(runtime, state));
+    }
+
+    @Override
+    public List<Variable> getParameters(PackageableElement element)
+    {
+        Service service = (Service) element;
+        PureExecution execution = (PureExecution) service.execution;
+
+        if (execution instanceof PureMultiExecution)
+        {
+            PureMultiExecution multiExecution = (PureMultiExecution) execution;
+            List<Variable> variables = new ArrayList<>(execution.func.parameters);
+            variables.add(0, new Variable(multiExecution.executionKey, "String", Multiplicity.PURE_ONE));
+            return variables;
+        }
+        else
+        {
+            return execution.func.parameters;
+        }
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
@@ -285,7 +285,25 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
                         "        data : '';\n" +
                         "        asserts : [];\n" +
                         "    }\n" +
+                        "}\n" +
+                        "Service test::service\n" +
+                        "{\n" +
+                        "    pattern: 'url/myUrl/';\n" +
+                        "    owners: ['ownerName'];\n" +
+                        "    documentation: 'test';\n" +
+                        "    autoActivateUpdates: true;\n" +
+                        "    execution: Multi\n" +
+                        "    {\n" +
+                        "        query: src:vscodelsp::test::Employee[1] | $src.hireType;\n" +
+                        "        key: 'env';\n" +
+                        "        executions['default']:\n" +
+                        "        {\n" +
+                        "           mapping: vscodelsp::test::EmployeeMapping;\n" +
+                        "           runtime: vscodelsp::test::H2Runtime;\n" +
+                        "        }\n" +
+                        "    }\n" +
                         "}");
+
 
         return codeFiles;
     }
@@ -408,5 +426,11 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         Set<String> actualCommands = Sets.mutable.empty();
         commands.forEach(c -> actualCommands.add(c.getId()));
         Assertions.assertEquals(expectedCommands, actualCommands);
+
+        LegendCommand singleServiceCommand = commands.stream().filter(x -> x.getId().equals(FunctionExecutionSupport.EXECUTE_COMMAND_ID) && x.getEntity().equals("vscodelsp::test::TestService")).findAny().get();
+        LegendCommand multiServiceCommand = commands.stream().filter(x -> x.getId().equals(FunctionExecutionSupport.EXECUTE_COMMAND_ID) && x.getEntity().equals("test::service")).findAny().get();
+
+        Assertions.assertEquals(Set.of("src"), singleServiceCommand.getInputParameters().keySet());
+        Assertions.assertEquals(Set.of("env", "src"), multiServiceCommand.getInputParameters().keySet());
     }
 }


### PR DESCRIPTION
This also fix a problems with variables, as the protocol changed.

![servie-multi](https://github.com/user-attachments/assets/fd96d16c-9498-4aa3-aa3c-07952df8dc96)
