### PR TITLE
Support for Service multi-execution test cases

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -17,6 +17,7 @@ package org.finos.legend.engine.ide.lsp.extension;
 import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -807,5 +808,35 @@ public abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExt
         Optional<LegendReferenceResolver> profileReference = LegendReferenceResolver.newReferenceResolver(taggedValue.tag.profileSourceInformation, x -> x.resolveProfile(taggedValue.tag.profile, taggedValue.tag.profileSourceInformation));
         Optional<LegendReferenceResolver> tagReference = LegendReferenceResolver.newReferenceResolver(taggedValue.tag.sourceInformation, x -> x.resolveTag(taggedValue.tag.profile, taggedValue.tag.value, taggedValue.tag.profileSourceInformation, taggedValue.tag.sourceInformation));
         return Stream.of(profileReference, tagReference);
+    }
+
+    protected <T> String toProtocolJson(T protocolObject)
+    {
+        try
+        {
+            return this.protocolMapper.writerWithDefaultPrettyPrinter().writeValueAsString(protocolObject);
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    protected <T> T cloneProtocolObject(T toClone)
+    {
+        if (toClone == null)
+        {
+            return null;
+        }
+
+        try (TokenBuffer tb = new TokenBuffer(this.protocolMapper, false))
+        {
+            this.protocolMapper.writeValue(tb, toClone);
+            return (T) this.protocolMapper.readValue(tb.asParser(), toClone.getClass());
+        }
+        catch (IOException e)
+        {
+            throw new UncheckedIOException(e);
+        }
     }
 }


### PR DESCRIPTION
This introduce a change on the Service protocol at parsing to massage the test cases so they fit better the VSCode flow.  

The ideal goal would be to push to Engine a change where a test suite can have a another test suite for "parameterized" test cases like these.  

But the protocol and compiler does not really support this, hence the tactical change.

The risk with this is around converting the Service back to grammar, but that is not something we do at the moment, and unlikely to introduce in the future as it will trample the style and formatting the user chose on their code.