### PR TITLE
Initial support for Notebooks

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CompileResult.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CompileResult.java
@@ -34,7 +34,7 @@ public class CompileResult extends AbstractLSPGrammarExtension.Result<PureModel>
         this.engineExceptions = pureModel.getEngineExceptions();
     }
 
-    CompileResult(Exception e, PureModelContextData pureModelContextData)
+    CompileResult(EngineException e, PureModelContextData pureModelContextData)
     {
         super(null, e);
         this.pureModelContextData = pureModelContextData;
@@ -49,12 +49,6 @@ public class CompileResult extends AbstractLSPGrammarExtension.Result<PureModel>
     public PureModelContextData getPureModelContextData()
     {
         return this.pureModelContextData;
-    }
-
-    @Override
-    public boolean hasException()
-    {
-        return hasEngineException() || this.e != null;
     }
 
     @Override

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/FunctionActivatorCommandsSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/FunctionActivatorCommandsSupport.java
@@ -79,7 +79,7 @@ public final class FunctionActivatorCommandsSupport implements CommandsSupport
         String entityPath = element.getPath();
 
         CompileResult compileResult = this.extension.getCompileResult(section);
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return Collections.singletonList(this.extension.errorResult(compileResult.getCompileErrorResult(), entityPath));
         }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/TestableCommandsSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/TestableCommandsSupport.java
@@ -193,7 +193,7 @@ public final class TestableCommandsSupport
         String entityPath = element.getPath();
         CompileResult compileResult = this.extension.getCompileResult(section);
 
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return List.of(LegendTestExecutionResult.error(compileResult.getCompileErrorResult(), entityPath));
         }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
@@ -236,7 +236,7 @@ public interface FunctionExecutionSupport
         AbstractLSPGrammarExtension extension = executionSupport.getExtension();
 
         CompileResult compileResult = extension.getCompileResult(section);
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return Collections.singletonList(extension.errorResult(compileResult.getCompileErrorResult(), entityPath));
         }
@@ -317,7 +317,7 @@ public interface FunctionExecutionSupport
         AbstractLSPGrammarExtension extension = executionSupport.getExtension();
 
         CompileResult compileResult = extension.getCompileResult(section);
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return Collections.singletonList(extension.errorResult(compileResult.getCompileErrorResult(), entityPath));
         }
@@ -427,7 +427,7 @@ public interface FunctionExecutionSupport
         AbstractLSPGrammarExtension extension = executionSupport.getExtension();
 
         CompileResult compileResult = extension.getCompileResult(section);
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return Collections.singletonList(extension.errorResult(compileResult.getCompileErrorResult(), entityPath));
         }
@@ -469,7 +469,7 @@ public interface FunctionExecutionSupport
         }
         catch (Exception e)
         {
-            LOGGER.warn("Unable to get local subject", e);
+            LOGGER.debug("Unable to get local subject", e);
         }
         return Optional.ofNullable(subject).map(Identity::makeIdentity).orElseGet(Identity::getAnonymousIdentity);
     }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/LegendTDSRequestHandlerImpl.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/LegendTDSRequestHandlerImpl.java
@@ -58,7 +58,7 @@ public class LegendTDSRequestHandlerImpl implements LegendTDSRequestHandler
         AbstractLSPGrammarExtension extension = functionExecutionSupport.getExtension();
 
         CompileResult compileResult = extension.getCompileResult(section);
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return extension.errorResult(compileResult.getCompileErrorResult(), entityPath);
         }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PureLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/PureLSPGrammarExtension.java
@@ -61,8 +61,6 @@ import org.finos.legend.engine.language.pure.grammar.from.antlr4.domain.DomainLe
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.domain.DomainParserGrammar;
 import org.finos.legend.engine.language.pure.grammar.from.domain.DomainParser;
 import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
-import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposer;
-import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
@@ -511,10 +509,8 @@ public class PureLSPGrammarExtension extends AbstractLegacyParserLSPGrammarExten
                     {
                         TextLocation codeBlockLocation = SourceInformationUtil.toLocation(sectionSourceCode.walkerSourceInformation.getSourceInformation(funcCtx.codeBlock()));
                         String functionExpression = section.getSection().getInterval(codeBlockLocation.getTextInterval().getStart().getLine(), codeBlockLocation.getTextInterval().getStart().getColumn(), autocompleteLocation.getLine(), autocompleteLocation.getColumn());
-                        // todo change so we can pass pure model directly...
-                        PureModelContextData pureModelContextData = this.getCompileResult(section).getPureModelContextData();
-                        String buildCodeContext = PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().build()).renderPureModelContextData(pureModelContextData);
-                        return new Completer(buildCodeContext, Lists.mutable.with(new RelationalCompleterExtension())).complete(functionExpression);
+                        PureModel pureModel = this.getCompileResult(section).getPureModel();
+                        return new Completer(pureModel, Lists.mutable.with(new RelationalCompleterExtension())).complete(functionExpression);
                     }).orElse(null);
         }
         catch (Exception e)

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
@@ -189,7 +189,7 @@ public class MappingLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
         }
 
         CompileResult compileResult = getCompileResult(section);
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return Collections.singletonList(errorResult(compileResult.getCompileErrorResult(), entityPath));
         }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension.notebook;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.tuple.Tuples;
+import org.finos.legend.engine.ide.lsp.extension.CompileResult;
+import org.finos.legend.engine.ide.lsp.extension.Constants;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.LegendReferenceResolver;
+import org.finos.legend.engine.ide.lsp.extension.SourceInformationUtil;
+import org.finos.legend.engine.ide.lsp.extension.core.FunctionExecutionSupport;
+import org.finos.legend.engine.ide.lsp.extension.core.FunctionExpressionNavigator;
+import org.finos.legend.engine.ide.lsp.extension.core.PureLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
+import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
+import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
+import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.HelperValueSpecificationBuilder;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserContext;
+import org.finos.legend.engine.language.pure.grammar.from.domain.DomainParser;
+import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
+import org.finos.legend.engine.plan.execution.PlanExecutionContext;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
+import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
+import org.finos.legend.engine.shared.javaCompiler.JavaCompileException;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+
+public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
+{
+    private static final FunctionExpressionNavigator FUNCTION_EXPRESSION_NAVIGATOR = new FunctionExpressionNavigator();
+    private DomainParser domainParser;
+    private PureGrammarParserContext parserContext;
+    private PureLSPGrammarExtension pureGrammarExtension;
+
+    @Override
+    public String getName()
+    {
+        return "purebook";
+    }
+
+    @Override
+    public void startup(GlobalState globalState)
+    {
+        this.domainParser = new DomainParser();
+        this.parserContext = new PureGrammarParserContext(PureGrammarParserExtensions.fromAvailableExtensions());
+        this.pureGrammarExtension = globalState.findGrammarExtensionThatImplements(PureLSPGrammarExtension.class)
+                .findAny()
+                .orElseThrow(() -> new UnsupportedOperationException("Notebook requires pure grammar extension"));
+    }
+
+    @Override
+    public void initialize(SectionState section)
+    {
+        this.parse(section);
+    }
+
+    private CompletableFuture<Lambda> parse(SectionState sectionState)
+    {
+        return sectionState.getProperty("PARSE_RESULT", () -> tryParse(sectionState));
+    }
+
+    private CompletableFuture<Lambda> tryParse(SectionState sectionState)
+    {
+        try
+        {
+            Lambda lambda = this.domainParser.parseLambda(
+                    sectionState.getSection().getText(true),
+                    this.parserContext,
+                    sectionState.getDocumentState().getDocumentId(),
+                    0,
+                    0,
+                    true
+            );
+            return CompletableFuture.completedFuture(lambda);
+        }
+        catch (Exception e)
+        {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private CompletableFuture<? extends LambdaFunction<?>> compile(SectionState sectionState)
+    {
+        return sectionState.getProperty("COMPILE_RESULT", () -> tryCompile(sectionState));
+    }
+
+    private CompletableFuture<? extends LambdaFunction<?>> tryCompile(SectionState sectionState)
+    {
+        return this.parse(sectionState).thenApply(x ->
+                {
+                    CompileResult compileResult = this.pureGrammarExtension.getCompileResult(sectionState);
+                    PureModel pureModel = compileResult.getPureModel();
+                    if (pureModel == null)
+                    {
+                        throw compileResult.getEngineException();
+                    }
+                    return HelperValueSpecificationBuilder.buildLambda(x, pureModel.getContext());
+                }
+                // when we complete compiling, trigger plan generation on the background to improve user experience...
+        ).whenCompleteAsync((l, e) -> this.generatePlan(sectionState), sectionState.getDocumentState().getGlobalState().getForkJoinPool());
+    }
+
+    @Override
+    public Iterable<? extends LegendDiagnostic> getDiagnostics(SectionState sectionState)
+    {
+        if (sectionState.getSection().getFullText().isEmpty())
+        {
+            return List.of();
+        }
+
+        try
+        {
+            try
+            {
+                this.compile(sectionState).get(30, TimeUnit.SECONDS);
+            }
+            catch (CompletionException | ExecutionException e)
+            {
+                throw e.getCause();
+            }
+        }
+        catch (EngineException e)
+        {
+            SourceInformation sourceInfo = e.getSourceInformation();
+            TextLocation location;
+            if (SourceInformationUtil.isValidSourceInfo(sourceInfo))
+            {
+                location = SourceInformationUtil.toLocation(sourceInfo);
+            }
+            else
+            {
+                location = TextLocation.newTextSource(sectionState.getDocumentState().getDocumentId(), sectionState.getSection().getTextInterval());
+            }
+
+            LegendDiagnostic.Source source = e.getErrorType() == EngineErrorType.PARSER ? LegendDiagnostic.Source.Parser : LegendDiagnostic.Source.Compiler;
+
+            return List.of(LegendDiagnostic.newDiagnostic(location, e.getMessage(), LegendDiagnostic.Kind.Error, source));
+        }
+        catch (Throwable t)
+        {
+            TextLocation location = TextLocation.newTextSource(sectionState.getDocumentState().getDocumentId(), sectionState.getSection().getTextInterval());
+            return List.of(LegendDiagnostic.newDiagnostic(location, t.getMessage(), LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Compiler));
+        }
+
+        return List.of();
+    }
+
+    @Override
+    public Stream<LegendReference> getLegendReferences(SectionState sectionState)
+    {
+        CompletableFuture<? extends LambdaFunction<?>> compiled = this.compile(sectionState);
+        try
+        {
+            LambdaFunction<?> lambdaFunction = compiled.get(30, TimeUnit.SECONDS);
+            PureModel pureModel = this.pureGrammarExtension.getCompileResult(sectionState).getPureModel();
+            return LegendReferenceResolver.toLegendReference(
+                    sectionState,
+                    FUNCTION_EXPRESSION_NAVIGATOR.findReferences(Optional.ofNullable(lambdaFunction)),
+                    pureModel.getContext()
+            );
+        }
+        catch (Exception ignore)
+        {
+            // ignore for now...
+        }
+        return Stream.empty();
+    }
+
+    @Override
+    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParameters)
+    {
+        switch (commandId)
+        {
+            case "executeCell":
+                return this.executeCell(section, inputParameters);
+            default:
+                return List.of();
+        }
+    }
+
+    private Iterable<? extends LegendExecutionResult> executeCell(SectionState section, Map<String, Object> inputParameters)
+    {
+        if (section.getSection().getFullText().isEmpty())
+        {
+            return List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "[]", "Nothing to execute!", section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters));
+        }
+
+        Pair<SingleExecutionPlan, PlanExecutionContext> planExecutionContextPair;
+
+        try
+        {
+            try
+            {
+                planExecutionContextPair = this.generatePlan(section).get(30, TimeUnit.SECONDS);
+            }
+            catch (CompletionException | ExecutionException e)
+            {
+                throw e.getCause();
+            }
+        }
+        catch (EngineException e)
+        {
+            return Lists.mutable.with(this.pureGrammarExtension.getExtension().errorResult(e, "Cannot execute since cell does not parse or compile.  Check diagnostics for further details...", "notebook_cell", section.getDocumentState().getTextLocation()));
+        }
+        catch (Throwable e)
+        {
+            return Lists.mutable.with(this.pureGrammarExtension.getExtension().errorResult(e, "Cannot generate an execution plan for given expression.  Likely the expression is not supported yet...", "notebook_cell", section.getDocumentState().getTextLocation()));
+        }
+
+        return this.executePlan(section, planExecutionContextPair, inputParameters);
+    }
+
+    private MutableList<LegendExecutionResult> executePlan(SectionState section, Pair<SingleExecutionPlan, PlanExecutionContext> planContext, Map<String, Object> inputParameters)
+    {
+        MutableList<LegendExecutionResult> results = Lists.mutable.empty();
+        FunctionExecutionSupport.executePlan(section.getDocumentState().getGlobalState(), this.pureGrammarExtension, section.getDocumentState().getDocumentId(), section.getSectionNumber(), planContext.getOne(), planContext.getTwo(), "notebook_cell", inputParameters, results);
+        return results;
+    }
+
+    private CompletableFuture<Pair<SingleExecutionPlan, PlanExecutionContext>> generatePlan(SectionState sectionState)
+    {
+        return sectionState.getProperty("PLAN_EXEC_CONTEXT", () -> tryGeneratePlan(sectionState));
+    }
+
+    private CompletableFuture<Pair<SingleExecutionPlan, PlanExecutionContext>> tryGeneratePlan(SectionState sectionState)
+    {
+        return this.compile(sectionState).thenApplyAsync(lambdaFunction ->
+        {
+            try
+            {
+                PureModel pureModel = this.pureGrammarExtension.getCompileResult(sectionState).getPureModel();
+                GlobalState globalState = sectionState.getDocumentState().getGlobalState();
+                SingleExecutionPlan singleExecutionPlan = FunctionExecutionSupport.generateSingleExecutionPlan(pureModel, globalState.getSetting(Constants.LEGEND_PROTOCOL_VERSION), lambdaFunction);
+                return Tuples.pair(singleExecutionPlan, new PlanExecutionContext(singleExecutionPlan, List.of()));
+            }
+            catch (JavaCompileException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }, sectionState.getDocumentState().getGlobalState().getForkJoinPool());
+    }
+}

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
@@ -220,7 +220,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
         }
 
         CompileResult compileResult = getCompileResult(section);
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return Collections.singletonList(errorResult(compileResult.getCompileErrorResult(), entityPath));
         }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
@@ -413,7 +413,7 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
         }
 
         CompileResult compileResult = getCompileResult(section);
-        if (compileResult.hasException())
+        if (compileResult.hasEngineException())
         {
             return Collections.singletonList(errorResult(compileResult.getCompileErrorResult(), entityPath));
         }

--- a/legend-engine-ide-lsp-default-extensions/src/main/resources/META-INF/services/org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension
+++ b/legend-engine-ide-lsp-default-extensions/src/main/resources/META-INF/services/org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension
@@ -8,3 +8,4 @@ org.finos.legend.engine.ide.lsp.extension.functionActivator.SnowflakeLSPGrammarE
 org.finos.legend.engine.ide.lsp.extension.functionActivator.HostedServiceLSPGrammarExtension
 org.finos.legend.engine.ide.lsp.extension.dataSpace.DataSpaceLSPGrammarExtension
 org.finos.legend.engine.ide.lsp.extension.diagram.DiagramLSPGrammarExtension
+org.finos.legend.engine.ide.lsp.extension.notebook.PureBookLSPGrammarExtension

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/StateForTestFactory.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/StateForTestFactory.java
@@ -29,6 +29,7 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
+import org.finos.legend.engine.ide.lsp.extension.state.NotebookDocumentState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.state.State;
 import org.finos.legend.engine.ide.lsp.extension.text.GrammarSection;
@@ -91,24 +92,39 @@ public class StateForTestFactory
 
     public SectionState newSectionState(String docId, String text)
     {
-        return this.newSectionState(docId, text, "Pure");
-    }
-
-    public SectionState newSectionState(String docId, String text, String grammar)
-    {
         TestGlobalState globalState = new TestGlobalState();
-        return this.newSectionState(globalState, docId, text, grammar);
+        return this.newSectionState(globalState, docId, text);
     }
 
-    public SectionState newSectionState(GlobalState gs, String docId, String text, String grammar)
+    public SectionState newSectionState(GlobalState gs, String docId, String text)
     {
         TestGlobalState globalState = (TestGlobalState) gs;
         LineIndexedText indexedText = LineIndexedText.index(text);
         TestDocumentState docState = new TestDocumentState(globalState, docId, indexedText);
-        TestSectionState sectionState = new TestSectionState(docState, 0, newGrammarSection(indexedText, grammar));
+        TestSectionState sectionState = new TestSectionState(docState, 0, newGrammarSection(indexedText));
 
         globalState.docStates.put(docId, docState);
         docState.sectionStates.add(sectionState);
+        gs.clearProperties();
+        return sectionState;
+    }
+
+    public SectionState newPureBookSectionState(String docId, String text)
+    {
+        TestGlobalState globalState = new TestGlobalState();
+        return this.newPureBookSectionState(globalState, docId, text);
+    }
+
+    public SectionState newPureBookSectionState(GlobalState gs, String docId, String text)
+    {
+        TestGlobalState globalState = (TestGlobalState) gs;
+        LineIndexedText indexedText = LineIndexedText.index(text);
+        TestDocumentState docState = new TestPureBookDocumentState(globalState, docId, indexedText);
+        TestSectionState sectionState = new TestSectionState(docState, 0, newGrammarSection(indexedText, "purebook"));
+
+        globalState.docStates.put(docId, docState);
+        docState.sectionStates.add(sectionState);
+        gs.clearProperties();
 
         return sectionState;
     }
@@ -321,6 +337,14 @@ public class StateForTestFactory
         public void forEachSectionState(Consumer<? super SectionState> consumer)
         {
             this.sectionStates.forEach(consumer);
+        }
+    }
+
+    private static class TestPureBookDocumentState extends TestDocumentState implements NotebookDocumentState
+    {
+        private TestPureBookDocumentState(GlobalState globalState, String id, LineIndexedText text)
+        {
+            super(globalState, id, text);
         }
     }
 

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/StateForTestFactory.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/StateForTestFactory.java
@@ -44,6 +44,7 @@ public class StateForTestFactory
     {
         this.legendLSPGrammarExtensions = loadAvailableExtensions();
         this.features = loadAvailableFeatures();
+        this.getLegendLSPGrammarExtensions().forEach(x -> x.startup(new TestGlobalState()));
     }
 
     public List<LegendLSPGrammarExtension> getLegendLSPGrammarExtensions()
@@ -83,12 +84,28 @@ public class StateForTestFactory
         return features;
     }
 
+    public GlobalState newGlobalState()
+    {
+        return new TestGlobalState();
+    }
+
     public SectionState newSectionState(String docId, String text)
     {
-        LineIndexedText indexedText = LineIndexedText.index(text);
+        return this.newSectionState(docId, text, "Pure");
+    }
+
+    public SectionState newSectionState(String docId, String text, String grammar)
+    {
         TestGlobalState globalState = new TestGlobalState();
+        return this.newSectionState(globalState, docId, text, grammar);
+    }
+
+    public SectionState newSectionState(GlobalState gs, String docId, String text, String grammar)
+    {
+        TestGlobalState globalState = (TestGlobalState) gs;
+        LineIndexedText indexedText = LineIndexedText.index(text);
         TestDocumentState docState = new TestDocumentState(globalState, docId, indexedText);
-        TestSectionState sectionState = new TestSectionState(docState, 0, newGrammarSection(indexedText));
+        TestSectionState sectionState = new TestSectionState(docState, 0, newGrammarSection(indexedText, grammar));
 
         globalState.docStates.put(docId, docState);
         docState.sectionStates.add(sectionState);
@@ -97,6 +114,11 @@ public class StateForTestFactory
     }
 
     protected static GrammarSection newGrammarSection(LineIndexedText indexedText)
+    {
+        return newGrammarSection(indexedText, "Pure");
+    }
+
+    protected static GrammarSection newGrammarSection(LineIndexedText indexedText, String defaultGrammar)
     {
         Matcher matcher = GRAMMAR_LINE_PATTERN.matcher(indexedText.getText());
         boolean hasGrammarLine;
@@ -113,7 +135,7 @@ public class StateForTestFactory
         else
         {
             hasGrammarLine = false;
-            grammar = "Pure";
+            grammar = defaultGrammar;
             startLine = 0;
             endLine = indexedText.getLineCount() - 1;
         }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestDefaultExtensions.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestDefaultExtensions.java
@@ -29,7 +29,7 @@ public class TestDefaultExtensions
     {
         MutableList<LegendLSPGrammarExtension> extensions = Lists.mutable.withAll(ServiceLoader.load(LegendLSPGrammarExtension.class));
         Assertions.assertEquals(
-                Sets.mutable.with("Pure", "Mapping", "Service", "Runtime", "Relational", "Connection", "Snowflake", "HostedService", "DataSpace", "Diagram"),
+                Sets.mutable.with("Pure", "Mapping", "Service", "Runtime", "Relational", "Connection", "Snowflake", "HostedService", "DataSpace", "Diagram", "purebook"),
                 extensions.collect(LegendLSPExtension::getName, Sets.mutable.empty())
         );
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestDefaultLegendLSPExtensionLoader.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/TestDefaultLegendLSPExtensionLoader.java
@@ -29,6 +29,7 @@ import org.finos.legend.engine.ide.lsp.extension.diagram.DiagramLSPGrammarExtens
 import org.finos.legend.engine.ide.lsp.extension.functionActivator.HostedServiceLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.functionActivator.SnowflakeLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.mapping.MappingLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.notebook.PureBookLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.relational.RelationalLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.runtime.RuntimeLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.service.ServiceLSPGrammarExtension;
@@ -62,6 +63,7 @@ class TestDefaultLegendLSPExtensionLoader
         expected.put("DataSpace", DataSpaceLSPGrammarExtension.class);
         expected.put("Diagram", DiagramLSPGrammarExtension.class);
         expected.put("ExternalFormat", DefaultLegendLSPExtensionLoader.CatchAllSectionParserLSPGrammarExtension.class);
+        expected.put("purebook", PureBookLSPGrammarExtension.class);
 
         MutableSet<String> missingOnActual = Sets.adapt(expected.keySet()).difference(Sets.adapt(grammarsMap.keySet()));
         Assertions.assertTrue(missingOnActual.isEmpty(), "Expected but missed on actual: " + missingOnActual);

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
@@ -20,12 +20,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.finos.legend.engine.ide.lsp.extension.StateForTestFactory;
+import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.core.FunctionExecutionSupport;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
+import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +60,7 @@ public class TestPureBookLSPGrammarExtension
     @Test
     void diagnostics()
     {
-        SectionState goodSection = stateForTestFactory.newSectionState("good.purebook", "1 + 1", "purebook");
+        SectionState goodSection = stateForTestFactory.newPureBookSectionState("good.purebook", "1 + 1");
         Iterable<? extends LegendDiagnostic> noDiagnostics = this.extension.getDiagnostics(goodSection);
 
         Assertions.assertEquals(
@@ -65,7 +68,7 @@ public class TestPureBookLSPGrammarExtension
                 noDiagnostics
         );
 
-        SectionState parseFailure = stateForTestFactory.newSectionState("parse_problem.purebook", "1 +", "purebook");
+        SectionState parseFailure = stateForTestFactory.newPureBookSectionState("parse_problem.purebook", "1 +");
         Iterable<? extends LegendDiagnostic> parseDiagnostics = this.extension.getDiagnostics(parseFailure);
 
         Assertions.assertEquals(
@@ -73,12 +76,20 @@ public class TestPureBookLSPGrammarExtension
                 parseDiagnostics
         );
 
-        SectionState compileFailure = stateForTestFactory.newSectionState("compile_problem.purebook", "does::not::exists()", "purebook");
+        SectionState compileFailure = stateForTestFactory.newPureBookSectionState("compile_problem.purebook", "does::not::exists()");
         Iterable<? extends LegendDiagnostic> compileDiagnostics = this.extension.getDiagnostics(compileFailure);
 
         Assertions.assertEquals(
                 List.of(LegendDiagnostic.newDiagnostic(TextLocation.newTextSource("compile_problem.purebook", 0, 0, 0, 16), "Can't resolve the builder for function 'does::not::exists' - stack:[build Lambda, new lambda, Applying does::not::exists]", LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Compiler)),
                 compileDiagnostics
+        );
+
+        SectionState wrongUsageOfPureBook = stateForTestFactory.newSectionState("wrongUsageOfPureBook.pure", "###purebook\n1 + 1");
+        Iterable<? extends LegendDiagnostic> wrongUsageOfPureBookDiagnostic = this.extension.getDiagnostics(wrongUsageOfPureBook);
+
+        Assertions.assertEquals(
+                List.of(LegendDiagnostic.newDiagnostic(TextLocation.newTextSource("wrongUsageOfPureBook.pure", 0, 0, 1, 5), "###purebook should not be use outside of Purebooks", LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Parser)),
+                wrongUsageOfPureBookDiagnostic
         );
     }
 
@@ -86,7 +97,7 @@ public class TestPureBookLSPGrammarExtension
     void references()
     {
         SectionState pureCode = stateForTestFactory.newSectionState("func.pure", "function hello::world():Any[1]{ 1 + 1 }");
-        SectionState notebook = stateForTestFactory.newSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "hello::world()", "purebook");
+        SectionState notebook = stateForTestFactory.newPureBookSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "hello::world()");
 
         List<LegendReference> references = this.extension.getLegendReferences(notebook).collect(Collectors.toList());
 
@@ -104,19 +115,27 @@ public class TestPureBookLSPGrammarExtension
     void executeCell()
     {
         SectionState pureCode = stateForTestFactory.newSectionState("func.pure", "function hello::world():Any[1]{ 1 + 1 }");
-        SectionState notebook = stateForTestFactory.newSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "hello::world()", "purebook");
+        SectionState notebook = stateForTestFactory.newPureBookSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "hello::world()");
         Assertions.assertEquals(
                 List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "2", null, notebook.getDocumentState().getDocumentId(), 0, Map.of())),
                 this.extension.execute(notebook, "notebook", "executeCell", Map.of())
         );
 
-        SectionState emptyNotebook = stateForTestFactory.newSectionState("notebook.purebook", "", "purebook");
+        // update code
+        stateForTestFactory.newSectionState(pureCode.getDocumentState().getGlobalState(), "func.pure", "function hello::world():Any[1]{ 1 + 2 }");
+
+        Assertions.assertEquals(
+                List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "3", null, notebook.getDocumentState().getDocumentId(), 0, Map.of())),
+                this.extension.execute(notebook, "notebook", "executeCell", Map.of())
+        );
+
+        SectionState emptyNotebook = stateForTestFactory.newPureBookSectionState("notebook.purebook", "");
         Assertions.assertEquals(
                 List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "[]", "Nothing to execute!", emptyNotebook.getDocumentState().getDocumentId(), 0, Map.of())),
                 this.extension.execute(emptyNotebook, "notebook", "executeCell", Map.of())
         );
 
-        SectionState cannotCompileNotebook = stateForTestFactory.newSectionState("notebook.purebook", "1 + 1 +", "purebook");
+        SectionState cannotCompileNotebook = stateForTestFactory.newPureBookSectionState("notebook.purebook", "1 + 1 +");
         LegendExecutionResult compileFailure = this.extension.execute(cannotCompileNotebook, "notebook", "executeCell", Map.of()).iterator().next();
         Assertions.assertEquals(
                 LegendExecutionResult.Type.ERROR,
@@ -127,7 +146,7 @@ public class TestPureBookLSPGrammarExtension
                 compileFailure.getMessage()
         );
 
-        SectionState failExecNotebook = stateForTestFactory.newSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "let a = hello::world();\nlet b = hello::world();", "purebook");
+        SectionState failExecNotebook = stateForTestFactory.newPureBookSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "let a = hello::world();\nlet b = hello::world();");
         LegendExecutionResult planGenFailure = this.extension.execute(failExecNotebook, "notebook", "executeCell", Map.of()).iterator().next();
         Assertions.assertEquals(
                 LegendExecutionResult.Type.ERROR,
@@ -136,6 +155,70 @@ public class TestPureBookLSPGrammarExtension
         Assertions.assertEquals(
                 "Cannot generate an execution plan for given expression.  Likely the expression is not supported yet...",
                 planGenFailure.getMessage()
+        );
+    }
+
+    @Test
+    void completions()
+    {
+        SectionState notebook = stateForTestFactory.newPureBookSectionState("notebook.purebook", "#>");
+        GlobalState gs = notebook.getDocumentState().getGlobalState();
+        stateForTestFactory.newSectionState(gs, "database.pure",
+                "###Relational\n" +
+                        "Database test::h2Store\n" +
+                        "(\n" +
+                        "    Table personTable\n" +
+                        "    (\n" +
+                        "     fullName VARCHAR(100),\n" +
+                        "     firmName VARCHAR(100),\n" +
+                        "     addressName VARCHAR(100)\n" +
+                        "    )\n" +
+                        "    Table anotherPersonTable\n" +
+                        "    (\n" +
+                        "     fullName VARCHAR(100),\n" +
+                        "     firmName VARCHAR(100),\n" +
+                        "     addressName VARCHAR(100)\n" +
+                        "    )\n" +
+                        ")");
+
+        stateForTestFactory.newSectionState(gs, "connection.pure",
+                "###Connection\n" +
+                        "RelationalDatabaseConnection test::h2Conn\n" +
+                        "{\n" +
+                        "    store: test::h2Store; \n" +
+                        "    type: H2;\n" +
+                        "    specification: LocalH2\n" +
+                        "    {\n" +
+                        "        testDataSetupCSV: 'default\\npersonTable\\nfullName,firmName,addressName\\nP1,F1,A1\\nP2,F2,A2\\nP3,,\\nP4,,A3\\nP5,F1,A1\\n---';\n" +
+                        "    };\n" +
+                        "    auth: DefaultH2;\n" +
+                        "}");
+
+        stateForTestFactory.newSectionState(gs, "runtime.pure",
+                "###Runtime\n" +
+                        "Runtime  test::h2Runtime\n" +
+                        "{\n" +
+                        "    mappings: [];\n" +
+                        "    connectionStores:\n" +
+                        "    [\n" +
+                        "        test::h2Conn: [ test::h2Store ]\n" +
+                        "    ];\n" +
+                        "}");
+
+        Iterable<? extends LegendCompletion> storeCompletions = this.extension.getCompletions(notebook, TextPosition.newPosition(0, 2));
+        Assertions.assertEquals(
+                List.of(new LegendCompletion("test::h2Store", ">{test::h2Store")),
+                storeCompletions
+        );
+
+        notebook = stateForTestFactory.newPureBookSectionState(gs, "notebook.purebook", "#>{test::h2Store.");
+
+        Iterable<? extends LegendCompletion> tableCompletions = this.extension.getCompletions(notebook, TextPosition.newPosition(0, 17));
+        Assertions.assertEquals(
+                List.of(new LegendCompletion("personTable", "personTable}"),
+                        new LegendCompletion("anotherPersonTable", "anotherPersonTable}")
+                ),
+                tableCompletions
         );
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension.notebook;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.finos.legend.engine.ide.lsp.extension.StateForTestFactory;
+import org.finos.legend.engine.ide.lsp.extension.core.FunctionExecutionSupport;
+import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
+import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
+import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestPureBookLSPGrammarExtension
+{
+    private static StateForTestFactory stateForTestFactory;
+    private final PureBookLSPGrammarExtension extension = new PureBookLSPGrammarExtension();
+
+    @BeforeEach
+    public void loadExtensionToUse()
+    {
+        this.extension.startup(stateForTestFactory.newGlobalState());
+    }
+
+    @BeforeAll
+    static void beforeAll()
+    {
+        stateForTestFactory = new StateForTestFactory();
+    }
+
+    @Test
+    public void testGetName()
+    {
+        Assertions.assertEquals("purebook", extension.getName());
+    }
+
+    @Test
+    void diagnostics()
+    {
+        SectionState goodSection = stateForTestFactory.newSectionState("good.purebook", "1 + 1", "purebook");
+        Iterable<? extends LegendDiagnostic> noDiagnostics = this.extension.getDiagnostics(goodSection);
+
+        Assertions.assertEquals(
+                List.of(),
+                noDiagnostics
+        );
+
+        SectionState parseFailure = stateForTestFactory.newSectionState("parse_problem.purebook", "1 +", "purebook");
+        Iterable<? extends LegendDiagnostic> parseDiagnostics = this.extension.getDiagnostics(parseFailure);
+
+        Assertions.assertEquals(
+                List.of(LegendDiagnostic.newDiagnostic(TextLocation.newTextSource("parse_problem.purebook", 0, 2, 0, 2), "Unexpected token", LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Parser)),
+                parseDiagnostics
+        );
+
+        SectionState compileFailure = stateForTestFactory.newSectionState("compile_problem.purebook", "does::not::exists()", "purebook");
+        Iterable<? extends LegendDiagnostic> compileDiagnostics = this.extension.getDiagnostics(compileFailure);
+
+        Assertions.assertEquals(
+                List.of(LegendDiagnostic.newDiagnostic(TextLocation.newTextSource("compile_problem.purebook", 0, 0, 0, 16), "Can't resolve the builder for function 'does::not::exists' - stack:[build Lambda, new lambda, Applying does::not::exists]", LegendDiagnostic.Kind.Error, LegendDiagnostic.Source.Compiler)),
+                compileDiagnostics
+        );
+    }
+
+    @Test
+    void references()
+    {
+        SectionState pureCode = stateForTestFactory.newSectionState("func.pure", "function hello::world():Any[1]{ 1 + 1 }");
+        SectionState notebook = stateForTestFactory.newSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "hello::world()", "purebook");
+
+        List<LegendReference> references = this.extension.getLegendReferences(notebook).collect(Collectors.toList());
+
+        Assertions.assertEquals(
+                List.of(LegendReference.builder()
+                        .withLocation("notebook.purebook", 0, 0, 0, 11)
+                        .withDeclarationLocation(TextLocation.newTextSource("func.pure", 0, 0, 0, 38))
+                        .build()
+                ),
+                references
+        );
+    }
+
+    @Test
+    void executeCell()
+    {
+        SectionState pureCode = stateForTestFactory.newSectionState("func.pure", "function hello::world():Any[1]{ 1 + 1 }");
+        SectionState notebook = stateForTestFactory.newSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "hello::world()", "purebook");
+        Assertions.assertEquals(
+                List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "2", null, notebook.getDocumentState().getDocumentId(), 0, Map.of())),
+                this.extension.execute(notebook, "notebook", "executeCell", Map.of())
+        );
+
+        SectionState emptyNotebook = stateForTestFactory.newSectionState("notebook.purebook", "", "purebook");
+        Assertions.assertEquals(
+                List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "[]", "Nothing to execute!", emptyNotebook.getDocumentState().getDocumentId(), 0, Map.of())),
+                this.extension.execute(emptyNotebook, "notebook", "executeCell", Map.of())
+        );
+
+        SectionState cannotCompileNotebook = stateForTestFactory.newSectionState( "notebook.purebook", "1 + 1 +", "purebook");
+        LegendExecutionResult compileFailure = this.extension.execute(cannotCompileNotebook, "notebook", "executeCell", Map.of()).iterator().next();
+        Assertions.assertEquals(
+                LegendExecutionResult.Type.ERROR,
+                compileFailure.getType()
+        );
+        Assertions.assertEquals(
+                "Cannot execute since cell does not parse or compile.  Check diagnostics for further details...",
+                compileFailure.getMessage()
+        );
+
+        SectionState failExecNotebook = stateForTestFactory.newSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "let a = hello::world();\nlet b = hello::world();", "purebook");
+        LegendExecutionResult planGenFailure = this.extension.execute(failExecNotebook, "notebook", "executeCell", Map.of()).iterator().next();
+        Assertions.assertEquals(
+                LegendExecutionResult.Type.ERROR,
+                planGenFailure.getType()
+        );
+        Assertions.assertEquals(
+                "Cannot generate an execution plan for given expression.  Likely the expression is not supported yet...",
+                planGenFailure.getMessage()
+        );
+    }
+}

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
@@ -116,7 +116,7 @@ public class TestPureBookLSPGrammarExtension
                 this.extension.execute(emptyNotebook, "notebook", "executeCell", Map.of())
         );
 
-        SectionState cannotCompileNotebook = stateForTestFactory.newSectionState( "notebook.purebook", "1 + 1 +", "purebook");
+        SectionState cannotCompileNotebook = stateForTestFactory.newSectionState("notebook.purebook", "1 + 1 +", "purebook");
         LegendExecutionResult compileFailure = this.extension.execute(cannotCompileNotebook, "notebook", "executeCell", Map.of()).iterator().next();
         Assertions.assertEquals(
                 LegendExecutionResult.Type.ERROR,

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPExtension.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPExtension.java
@@ -15,6 +15,7 @@
 package org.finos.legend.engine.ide.lsp.extension;
 
 import java.util.Set;
+import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 
 /**
  * An LSP extension for Legend Engine representing some kind of grammar or DSL.
@@ -36,5 +37,10 @@ public interface LegendLSPExtension
     default Iterable<? extends String> getKeywords()
     {
         return Set.of();
+    }
+
+    default void destroy(SectionState sectionState)
+    {
+
     }
 }

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
@@ -114,7 +114,7 @@ public interface LegendLSPGrammarExtension extends LegendLSPExtension
      */
     default Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs)
     {
-        return Collections.emptyList();
+        return this.execute(section, entityPath, commandId, executableArgs, Map.of());
     }
 
     /**
@@ -127,7 +127,7 @@ public interface LegendLSPGrammarExtension extends LegendLSPExtension
      */
     default Optional<LegendReference> getLegendReference(SectionState sectionState, TextPosition textPosition)
     {
-        return Optional.empty();
+        return getLegendReferences(sectionState).filter(x -> x.getLocation().getTextInterval().includes(textPosition)).findAny();
     }
 
     /**

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/state/NotebookDocumentState.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/state/NotebookDocumentState.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension.state;
+
+public interface NotebookDocumentState extends DocumentState
+{
+
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendNotebookDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendNotebookDocumentService.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.server;
+
+import java.util.List;
+import org.eclipse.lsp4j.DidChangeNotebookDocumentParams;
+import org.eclipse.lsp4j.DidCloseNotebookDocumentParams;
+import org.eclipse.lsp4j.DidOpenNotebookDocumentParams;
+import org.eclipse.lsp4j.DidSaveNotebookDocumentParams;
+import org.eclipse.lsp4j.NotebookDocumentChangeEventCellStructure;
+import org.eclipse.lsp4j.NotebookDocumentChangeEventCellTextContent;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.services.NotebookDocumentService;
+import org.finos.legend.engine.ide.lsp.text.LineIndexedText;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LegendNotebookDocumentService implements NotebookDocumentService
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(LegendNotebookDocumentService.class);
+
+    private final LegendLanguageServer server;
+
+    LegendNotebookDocumentService(LegendLanguageServer server)
+    {
+        this.server = server;
+    }
+
+    @Override
+    public void didOpen(DidOpenNotebookDocumentParams params)
+    {
+        params.getCellTextDocuments().forEach(this::openNotebookDocument);
+    }
+
+    private void openNotebookDocument(TextDocumentItem textDocumentItem)
+    {
+        LegendServerGlobalState.LegendServerDocumentState docState = this.server.getGlobalState().getOrCreateNotebookDocState(textDocumentItem.getUri());
+        docState.change(textDocumentItem.getVersion(), LineIndexedText.index(textDocumentItem.getText()));
+    }
+
+    @Override
+    public void didChange(DidChangeNotebookDocumentParams params)
+    {
+        // structure for when cells are added / removed
+        NotebookDocumentChangeEventCellStructure structure = params.getChange().getCells().getStructure();
+        if (structure != null)
+        {
+            // new cells
+            structure.getDidOpen().forEach(this::openNotebookDocument);
+            // removed cells
+            structure.getDidClose().forEach(this::closeNotebookDocument);
+        }
+
+        // actual changes to cell content
+        List<NotebookDocumentChangeEventCellTextContent> textContent = params.getChange().getCells().getTextContent();
+        if (textContent != null)
+        {
+            textContent.forEach(textContentForCell ->
+            {
+                VersionedTextDocumentIdentifier document = textContentForCell.getDocument();
+                LegendServerGlobalState.LegendServerDocumentState documentState = this.server.getGlobalState().getDocumentState(document.getUri());
+
+                if (LegendTextDocumentService.applyChanges(documentState, document.getVersion(), textContentForCell.getChanges()))
+                {
+                    LOGGER.debug("Changed {} (version {})", document.getUri(), document.getVersion());
+                }
+            });
+        }
+    }
+
+    @Override
+    public void didSave(DidSaveNotebookDocumentParams params)
+    {
+        // should not happen...
+    }
+
+    @Override
+    public void didClose(DidCloseNotebookDocumentParams params)
+    {
+
+    }
+
+    private void closeNotebookDocument(TextDocumentIdentifier x)
+    {
+        this.server.getGlobalState().deleteDocState(x.getUri(), false);
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendTextDocumentService.java
@@ -73,6 +73,7 @@ import org.finos.legend.engine.ide.lsp.extension.text.TextInterval;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
 import org.finos.legend.engine.ide.lsp.server.LegendServerGlobalState.LegendServerDocumentState;
+import org.finos.legend.engine.ide.lsp.text.LineIndexedText;
 import org.finos.legend.engine.ide.lsp.text.TextTools;
 import org.finos.legend.engine.ide.lsp.utils.LegendToLSPUtilities;
 import org.slf4j.Logger;
@@ -125,34 +126,40 @@ public class LegendTextDocumentService implements TextDocumentService
 
         List<TextDocumentContentChangeEvent> changes = params.getContentChanges();
 
-        if (changes.size() > 1)
+        if (applyChanges(docState, doc.getVersion(), changes))
         {
-            String message = "Expected at most one change to " + uri + ", got " + changes.size() + "; processing only the first";
-            LOGGER.warn(message);
-            this.server.logWarningToClient(message);
-        }
-
-        if (changes.isEmpty())
-        {
-            LOGGER.debug("No changes to {}", uri);
-            docState.change(doc.getVersion());
-            return;
-        }
-
-        LegendServerDocumentState finalDocState = docState;
-
-        this.server.runPossiblyAsync(() ->
-        {
-            if (finalDocState.change(doc.getVersion(), changes.get(0).getText()))
+            this.server.runPossiblyAsync(() ->
             {
                 globalState.clearProperties();
                 this.server.getLanguageClient().refreshDiagnostics();
                 this.server.getLanguageClient().refreshSemanticTokens();
                 this.server.getLanguageClient().refreshCodeLenses();
-            }
+                LOGGER.debug("Changed {} (version {})", uri, doc.getVersion());
+            });
+        }
+    }
 
-            LOGGER.debug("Changed {} (version {})", uri, doc.getVersion());
-        });
+    public static boolean applyChanges(LegendServerDocumentState finalDocState, Integer version, List<TextDocumentContentChangeEvent> changes)
+    {
+        LineIndexedText indexedText = finalDocState.getIndexedText();
+        for (TextDocumentContentChangeEvent changeEvent : changes)
+        {
+            if (changeEvent.getRange() == null)
+            {
+                indexedText = LineIndexedText.index(changeEvent.getText());
+            }
+            else
+            {
+                indexedText = indexedText.replace(
+                        changeEvent.getText(),
+                        changeEvent.getRange().getStart().getLine(),
+                        changeEvent.getRange().getStart().getCharacter(),
+                        changeEvent.getRange().getEnd().getLine(),
+                        changeEvent.getRange().getEnd().getCharacter()
+                );
+            }
+        }
+        return finalDocState.change(version, indexedText);
     }
 
     @Override

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/text/GrammarSectionIndex.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/text/GrammarSectionIndex.java
@@ -93,6 +93,12 @@ public class GrammarSectionIndex
         return this.text.getText();
     }
 
+    public LineIndexedText getIndexedText()
+    {
+        return this.text;
+    }
+
+
     /**
      * Get the number of lines in the text.
      *
@@ -255,16 +261,30 @@ public class GrammarSectionIndex
      */
     public static GrammarSectionIndex parse(LineIndexedText text)
     {
+        return parse(text, PURE_GRAMMAR_NAME);
+    }
+
+    /**
+     * Parse the given text document and return the resulting {@link GrammarSectionIndex}.
+     *
+     * If no explicit section is found, will use the provided one
+     *
+     * @param text line indexed text document
+     * @param defaultGrammarName default grammar to use if no explicit section grammar found
+     * @return grammar section index
+     */
+    public static GrammarSectionIndex parse(LineIndexedText text, String defaultGrammarName)
+    {
         Matcher matcher = GRAMMAR_LINE_PATTERN.matcher(text.getText());
         if (!matcher.find())
         {
-            return new GrammarSectionIndex(text, newGrammarSection(text, false, PURE_GRAMMAR_NAME, 0, text.getLineCount() - 1));
+            return new GrammarSectionIndex(text, newGrammarSection(text, false, defaultGrammarName, 0, text.getLineCount() - 1));
         }
 
         List<GrammarSection> sections = new ArrayList<>();
         if ((matcher.start() > 0) && !TextTools.isBlank(text.getText(), 0, matcher.start()))
         {
-            sections.add(newGrammarSection(text, false, PURE_GRAMMAR_NAME, 0, text.getLineNumber(matcher.start() - 1)));
+            sections.add(newGrammarSection(text, false, defaultGrammarName, 0, text.getLineNumber(matcher.start() - 1)));
         }
 
         int index = matcher.start();

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/TestLegendTextDocumentService.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/TestLegendTextDocumentService.java
@@ -273,21 +273,19 @@ public class TestLegendTextDocumentService
                     position
             );
             List<CompletionItem> items = service.completion(completionParams).join().getLeft();
-            Assertions.assertEquals(2, items.size());
             Assertions.assertEquals(expected, items.stream().map(CompletionItem::getLabel).collect(Collectors.toSet()));
         };
 
-        Set<String> expected = Set.of("###TestGrammar", "###EmptyGrammar");
         // start of line
-        asserter.accept(new Position(9, 0), expected);
+        asserter.accept(new Position(9, 0), Set.of("###TestGrammar", "###EmptyGrammar"));
         // with # preceding
-        asserter.accept(new Position(9, 1), expected);
+        asserter.accept(new Position(9, 1), Set.of("###TestGrammar", "###EmptyGrammar"));
         // with ## preceding
-        asserter.accept(new Position(9, 2), expected);
+        asserter.accept(new Position(9, 2), Set.of("###TestGrammar", "###EmptyGrammar"));
         // with ### preceding
-        asserter.accept(new Position(9, 3), expected);
+        asserter.accept(new Position(9, 3), Set.of("###TestGrammar", "###EmptyGrammar"));
         // with ###T preceding
-        asserter.accept(new Position(9, 4), expected);
+        asserter.accept(new Position(9, 4), Set.of("###TestGrammar"));
     }
 
     @Test

--- a/legend-engine-ide-lsp-text-tools/src/main/java/org/finos/legend/engine/ide/lsp/text/LineIndexedText.java
+++ b/legend-engine-ide-lsp-text-tools/src/main/java/org/finos/legend/engine/ide/lsp/text/LineIndexedText.java
@@ -358,4 +358,32 @@ public class LineIndexedText
     {
         return new LineIndexedText(text);
     }
+
+    public LineIndexedText replace(String toReplace, int startLine, int startCharacter, int endLine, int endCharacter)
+    {
+        // change is up to end of current text
+        if (this.getLineCount() - 1 == endLine
+                && this.getLineLength(endLine) == endCharacter)
+        {
+            // change is at the end of current text
+            if (startLine == endLine && startCharacter == endCharacter)
+            {
+                return LineIndexedText.index(this.getText() + toReplace);
+            }
+            else
+            {
+                int splitIndex = this.getIndex(startLine, startCharacter);
+                String prefix = this.getText().substring(0, splitIndex);
+                return LineIndexedText.index(prefix + toReplace);
+            }
+        }
+        else
+        {
+            int splitStartIndex = this.getIndex(startLine, startCharacter);
+            int splitEndIndex = this.getIndex(endLine, endCharacter);
+            String prefix = this.getText().substring(0, splitStartIndex);
+            String suffix = this.getText().substring(splitEndIndex);
+            return LineIndexedText.index(prefix + toReplace + suffix);
+        }
+    }
 }

--- a/legend-engine-ide-lsp-text-tools/src/test/java/org/finos/legend/engine/ide/lsp/text/TestLineIndexedText.java
+++ b/legend-engine-ide-lsp-text-tools/src/test/java/org/finos/legend/engine/ide/lsp/text/TestLineIndexedText.java
@@ -227,4 +227,17 @@ public class TestLineIndexedText
         }
         Assertions.assertFalse(indexedText.isValidIndex(indexedText.getText().length()));
     }
+
+    @Test
+    void replace()
+    {
+        Assertions.assertEquals("hello", LineIndexedText.index("").replace("hello", 0, 0, 0, 0).getText(), "insert on empty text");
+        Assertions.assertEquals("hello world", LineIndexedText.index("world").replace("hello ", 0, 0, 0, 0).getText(), "insert at start of text");
+        Assertions.assertEquals("hello world", LineIndexedText.index("hello").replace(" world", 0, 5, 0, 5).getText(), "insert at end of text");
+        Assertions.assertEquals("hello\nworld", LineIndexedText.index("hello\n").replace("world", 1, 0, 1, 0).getText(), "insert at start of second line");
+        Assertions.assertEquals("hello world\nBye!", LineIndexedText.index("hello\nBye!").replace(" world", 0, 5, 0, 5).getText(), "insert at end of first line");
+        Assertions.assertEquals("hello\n", LineIndexedText.index("hello\nBye!").replace("", 1, 0, 1, 4).getText(), "replace end of text");
+        Assertions.assertEquals("hello\nBye!", LineIndexedText.index("hello world\nBye!").replace("", 0, 5, 0, 11).getText(), "replace between line");
+        Assertions.assertEquals("hello\n", LineIndexedText.index("hello world\nBye!\n").replace("", 0, 5, 1, 4).getText(), "replace multi-line");
+    }
 }


### PR DESCRIPTION
This introduce the support for notebooks.  As part of this

- Create the notebook service
- Enhance document changes to be incremental, as notebook only support incremental updates
- To fit with existing design, create a pseudo-grammar extension, **_purebook_**, to handle the code within the notebook cell, treating them as lambdas