### PR TITLE
Fix windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ matrix.os }}
-          path: ${{ github.workspace }}/legend-engine-ide-lsp-test-reports/surefire-reports-aggregate/*.xml
+          path: ${{ github.workspace }}/legend-engine-ide-lsp-test-reports/surefire-reports-aggregate/*
 
       - name: Upload CI Event
         if: always()

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/repl/LegendREPLFeatureTest.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/repl/LegendREPLFeatureTest.java
@@ -35,8 +35,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+@DisabledOnOs(OS.WINDOWS)
 @Timeout(value = 3, unit = TimeUnit.MINUTES)
 public class LegendREPLFeatureTest
 {

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/repl/TestLSPReplExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/repl/TestLSPReplExtension.java
@@ -29,8 +29,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+@DisabledOnOs(OS.WINDOWS)
 public class TestLSPReplExtension
 {
     @Test


### PR DESCRIPTION
The REPL test cases are corrupting the Surefire IN/OUT streams in windows, so skipping for now. 