### PR TITLE
Keeping a single execute method

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtension.java
@@ -36,7 +36,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.block.function.checked.ThrowingFunction;
@@ -252,12 +251,6 @@ public abstract class AbstractLSPGrammarExtension implements LegendLSPGrammarExt
     protected void collectCommands(SectionState sectionState, PackageableElement element, CommandConsumer consumer)
     {
         this.commandsSupports.forEach(x -> x.collectCommands(sectionState, element, consumer));
-    }
-
-    @Override
-    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs)
-    {
-        return execute(section, entityPath, commandId, executableArgs, Maps.mutable.empty());
     }
 
     @Override

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
@@ -92,9 +92,7 @@ public class ConnectionLSPGrammarExtension extends AbstractLegacyParserLSPGramma
     @Override
     public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams)
     {
-        return GENERATE_DB_COMMAND_ID.equals(commandId) ?
-                generateDBFromConnection(section, entityPath) :
-                super.execute(section, entityPath, commandId, executableArgs);
+        return GENERATE_DB_COMMAND_ID.equals(commandId) ? generateDBFromConnection(section, entityPath) : super.execute(section, entityPath, commandId, executableArgs, Map.of());
     }
 
     @Override

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
@@ -188,7 +188,7 @@ public class MappingLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
             }
             default:
             {
-                return super.execute(section, entityPath, commandId, executableArgs);
+                return super.execute(section, entityPath, commandId, executableArgs, Map.of());
             }
         }
     }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
@@ -205,9 +205,7 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
     @Override
     public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams)
     {
-        return GENERATE_MODEL_MAPPING_COMMAND_ID.equals(commandId) ?
-                generateModelsFromDatabaseSpecification(section, entityPath) :
-                super.execute(section, entityPath, commandId, executableArgs);
+        return GENERATE_MODEL_MAPPING_COMMAND_ID.equals(commandId) ? generateModelsFromDatabaseSpecification(section, entityPath) : super.execute(section, entityPath, commandId, executableArgs, Map.of());
     }
 
     private Iterable<? extends LegendExecutionResult> generateModelsFromDatabaseSpecification(SectionState section, String entityPath)

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
@@ -335,7 +335,7 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
             }
             default:
             {
-                return super.execute(section, entityPath, commandId, executableArgs);
+                return super.execute(section, entityPath, commandId, executableArgs, Map.of());
             }
         }
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
@@ -14,8 +14,13 @@
 
 package org.finos.legend.engine.ide.lsp.extension;
 
+import java.lang.reflect.ParameterizedType;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
@@ -28,13 +33,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.ParameterizedType;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 public abstract class AbstractLSPGrammarExtensionTest<T extends LegendLSPGrammarExtension>
 {
@@ -112,17 +110,17 @@ public abstract class AbstractLSPGrammarExtensionTest<T extends LegendLSPGrammar
     protected Iterable<? extends LegendExecutionResult> testCommand(String code, String entityPath, String command)
     {
         SectionState sectionState = stateForTestFactory.newSectionState(DOC_ID_FOR_TEXT, code);
-        return this.extension.execute(sectionState, entityPath, command, Maps.fixedSize.empty());
+        return this.extension.execute(sectionState, entityPath, command, Map.of(), Map.of());
     }
 
     protected Iterable<? extends LegendExecutionResult> testCommand(SectionState sectionState, String entityPath, String command)
     {
-        return this.extension.execute(sectionState, entityPath, command, Maps.fixedSize.empty());
+        return this.extension.execute(sectionState, entityPath, command, Map.of(), Map.of());
     }
 
     protected Iterable<? extends LegendExecutionResult> testCommand(SectionState sectionState, String entityPath, String command, Map<String, String> executableArgs)
     {
-        return this.extension.execute(sectionState, entityPath, command, executableArgs);
+        return this.extension.execute(sectionState, entityPath, command, executableArgs, Map.of());
     }
 
     protected Iterable<? extends LegendExecutionResult> testCommand(SectionState sectionState, String entityPath, String command, Map<String, String> executableArgs, Map<String, Object> inputParams)

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
@@ -118,7 +118,7 @@ public class TestPureBookLSPGrammarExtension
         SectionState notebook = stateForTestFactory.newPureBookSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "hello::world()");
         Assertions.assertEquals(
                 List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "2", null, notebook.getDocumentState().getDocumentId(), 0, Map.of())),
-                this.extension.execute(notebook, "notebook", "executeCell", Map.of())
+                this.extension.execute(notebook, "notebook", "executeCell", Map.of(), Map.of())
         );
 
         // update code
@@ -126,17 +126,17 @@ public class TestPureBookLSPGrammarExtension
 
         Assertions.assertEquals(
                 List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "3", null, notebook.getDocumentState().getDocumentId(), 0, Map.of())),
-                this.extension.execute(notebook, "notebook", "executeCell", Map.of())
+                this.extension.execute(notebook, "notebook", "executeCell", Map.of(), Map.of())
         );
 
         SectionState emptyNotebook = stateForTestFactory.newPureBookSectionState("notebook.purebook", "");
         Assertions.assertEquals(
                 List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "[]", "Nothing to execute!", emptyNotebook.getDocumentState().getDocumentId(), 0, Map.of())),
-                this.extension.execute(emptyNotebook, "notebook", "executeCell", Map.of())
+                this.extension.execute(emptyNotebook, "notebook", "executeCell", Map.of(), Map.of())
         );
 
         SectionState cannotCompileNotebook = stateForTestFactory.newPureBookSectionState("notebook.purebook", "1 + 1 +");
-        LegendExecutionResult compileFailure = this.extension.execute(cannotCompileNotebook, "notebook", "executeCell", Map.of()).iterator().next();
+        LegendExecutionResult compileFailure = this.extension.execute(cannotCompileNotebook, "notebook", "executeCell", Map.of(), Map.of()).iterator().next();
         Assertions.assertEquals(
                 LegendExecutionResult.Type.ERROR,
                 compileFailure.getType()
@@ -147,7 +147,7 @@ public class TestPureBookLSPGrammarExtension
         );
 
         SectionState failExecNotebook = stateForTestFactory.newPureBookSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "let a = hello::world();\nlet b = hello::world();");
-        LegendExecutionResult planGenFailure = this.extension.execute(failExecNotebook, "notebook", "executeCell", Map.of()).iterator().next();
+        LegendExecutionResult planGenFailure = this.extension.execute(failExecNotebook, "notebook", "executeCell", Map.of(), Map.of()).iterator().next();
         Assertions.assertEquals(
                 LegendExecutionResult.Type.ERROR,
                 planGenFailure.getType()
@@ -218,7 +218,7 @@ public class TestPureBookLSPGrammarExtension
                         "|      P5      |      F1      |      A1      |\n" +
                         "+--------------+--------------+--------------+\n" +
                         "5 rows -- 3 columns", null, notebook.getDocumentState().getDocumentId(), 0, Map.of())),
-                this.extension.execute(notebook, "notebook", "executeCell", Map.of())
+                this.extension.execute(notebook, "notebook", "executeCell", Map.of(), Map.of())
         );
 
 

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
@@ -104,20 +104,6 @@ public interface LegendLSPGrammarExtension extends LegendLSPExtension
     }
 
     /**
-     * Execute a Legend command on an entity in a section.
-     *
-     * @param section    grammar section state
-     * @param entityPath entity path
-     * @param commandId  command id
-     * @param executableArgs executable Arguments
-     * @return execution results
-     */
-    default Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs)
-    {
-        return this.execute(section, entityPath, commandId, executableArgs, Map.of());
-    }
-
-    /**
      * If the given text position refers to another element, this returns the location where the reference (needs to include the text position),
      * and the location where the referenced is defined, enabling navigation from one to the other. If a reference cannot be resolved, an empty optional should be returned.
      *


### PR DESCRIPTION
This also reduce the REPL integration test process parameters to avoid argument too long on some environments. 