### PR TITLE
Add entityPath property to LegendWriteEntityRequest

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/sdlc/LegendSDLCFeatureImpl.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/sdlc/LegendSDLCFeatureImpl.java
@@ -17,7 +17,6 @@
 package org.finos.legend.engine.ide.lsp.extension.sdlc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.collections.api.block.function.Function0;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.factory.Sets;
@@ -147,7 +146,7 @@ public class LegendSDLCFeatureImpl implements LegendSDLCFeature
     }
 
     @Override
-    public Map.Entry<String, String> contentToPureText(Map<String, ?> content)
+    public String contentToPureText(Map<String, ?> content)
     {
         PackageableElement packageableElement = this.objectMapper.convertValue(content, PackageableElement.class);
         String pureText = this.pureGrammarComposer.renderPureModelContextData(PureModelContextData.newBuilder().withElement(packageableElement).build());
@@ -155,7 +154,7 @@ public class LegendSDLCFeatureImpl implements LegendSDLCFeature
         {
             pureText = pureText.substring(pureText.indexOf('\n') + 1);
         }
-        return Pair.of(packageableElement.getPath(), pureText.strip());
+        return pureText.strip();
     }
 
     @Override

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendSDLCFeature.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendSDLCFeature.java
@@ -93,7 +93,7 @@ public interface LegendSDLCFeature extends LegendLSPFeature
      */
     Map<Path, String> convertToOneElementPerFile(Path rootFolder, DocumentState documentState);
 
-    Map.Entry<String, String> contentToPureText(Map<String, ?> content);
+    String contentToPureText(Map<String, ?> content);
 
     /**
      * Return the mapping of type to classifier path.

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageService.java
@@ -451,10 +451,8 @@ public class LegendLanguageService implements LegendLanguageServiceContract
                 {
                     LegendSDLCFeature handler = this.getSDLCHandler();
 
-                    Map.Entry<String, String> pathToText = handler.contentToPureText(request.getContent());
-
-                    String path = pathToText.getKey();
-                    String pureText = pathToText.getValue();
+                    String path = request.getEntityPath();
+                    String pureText = handler.contentToPureText(request.getContent());
 
                     LegendEntity entity = entities.stream().filter(x -> x.getPath().equals(path)).findAny().orElseThrow(() -> new RuntimeException("Element not found in project: " + path));
                     TextLocation location = entity.getLocation();

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/request/LegendWriteEntityRequest.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/request/LegendWriteEntityRequest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 public class LegendWriteEntityRequest
 {
+    private String entityPath;
     private Map<String, ?> content;
 
     public LegendWriteEntityRequest()
@@ -27,9 +28,15 @@ public class LegendWriteEntityRequest
 
     }
 
-    public LegendWriteEntityRequest(Map<String, ?> content)
+    public LegendWriteEntityRequest(String entityPath, Map<String, ?> content)
     {
+        this.entityPath = entityPath;
         this.content = content;
+    }
+
+    public String getEntityPath()
+    {
+        return entityPath;
     }
 
     public Map<String, ?> getContent()

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerSDLCIntegration.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerSDLCIntegration.java
@@ -523,7 +523,7 @@ public class TestLegendLanguageServerSDLCIntegration
                 "  \"package\": \"one\"\n" +
                 "}";
 
-        writeEntity(classEntityToWrite);
+        writeEntity("one::element", classEntityToWrite);
 
         String mappingToWrite = "{\n" +
                 "  \"_type\": \"mapping\",\n" +
@@ -566,7 +566,7 @@ public class TestLegendLanguageServerSDLCIntegration
                 "  \"package\": \"vscodelsp::test\"\n" +
                 "}";
 
-        writeEntity(mappingToWrite);
+        writeEntity("vscodelsp::test::EmployeeMapping", mappingToWrite);
 
         String diagramEntityToWrite = "{\n" +
                 "  \"_type\": \"diagram\",\n" +
@@ -590,7 +590,7 @@ public class TestLegendLanguageServerSDLCIntegration
                 "  \"propertyViews\": []\n" +
                 "}";
 
-        writeEntity(diagramEntityToWrite);
+        writeEntity("showcase::northwind::model::NorthwindModelDiagram1", diagramEntityToWrite);
 
         List<ApplyWorkspaceEditParams> workspaceEdits = extension.getClient().workspaceEdits;
         Assertions.assertEquals(3, workspaceEdits.size());
@@ -679,10 +679,10 @@ public class TestLegendLanguageServerSDLCIntegration
         return new GsonBuilder().setPrettyPrinting().create().toJson(mappingElementDocumentChanges.get(0).getLeft());
     }
 
-    private static void writeEntity(String classEntityToWrite) throws Exception
+    private static void writeEntity(String entityPath, String classEntityToWrite) throws Exception
     {
         Map<String, ?> entityContent = new Gson().fromJson(classEntityToWrite, Map.class);
-        LegendWriteEntityRequest request = new LegendWriteEntityRequest(entityContent);
+        LegendWriteEntityRequest request = new LegendWriteEntityRequest(entityPath, entityContent);
         extension.futureGet(extension.getServer().getLegendLanguageService().writeEntity(request));
     }
 }


### PR DESCRIPTION
This PR adds an `entityPath` property to the `LegendWriteEntityRequest` class so that write entity classes can specify the specific entity ID they want to write to, rather than inferring the entity ID from the entity content. This effectively allows us to rename an entity by specifying an existing entityPath but writing an entity with a new path in the request content.