### PR TITLE
Support to be able to cancel requests

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CommandsSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/CommandsSupport.java
@@ -19,6 +19,7 @@ package org.finos.legend.engine.ide.lsp.extension;
 import java.util.Map;
 import java.util.Set;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 
@@ -28,5 +29,5 @@ interface CommandsSupport
 
     void collectCommands(SectionState sectionState, PackageableElement element, CommandConsumer consumer);
 
-    Iterable<? extends LegendExecutionResult> executeCommand(SectionState section, PackageableElement element, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParameters);
+    Iterable<? extends LegendExecutionResult> executeCommand(SectionState section, PackageableElement element, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParameters, CancellationToken requestId);
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/FunctionActivatorCommandsSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/FunctionActivatorCommandsSupport.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
 import org.finos.legend.engine.protocol.functionActivator.metamodel.FunctionActivator;
@@ -73,7 +74,7 @@ public final class FunctionActivatorCommandsSupport implements CommandsSupport
     }
 
     @Override
-    public Iterable<? extends LegendExecutionResult> executeCommand(SectionState section, PackageableElement element, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParameters)
+    public Iterable<? extends LegendExecutionResult> executeCommand(SectionState section, PackageableElement element, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParameters, CancellationToken requestId)
     {
         TextLocation location = SourceInformationUtil.toLocation(element.sourceInformation);
         String entityPath = element.getPath();

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendEngineServerClient.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendEngineServerClient.java
@@ -15,19 +15,25 @@
 package org.finos.legend.engine.ide.lsp.extension;
 
 import java.io.InputStream;
+import java.util.function.Consumer;
 import org.eclipse.collections.impl.block.function.checked.ThrowingFunction;
 
 public interface LegendEngineServerClient
 {
+    Consumer<Runnable> NO_CANCEL_LISTENER = x ->
+    {
+
+    };
+
     default boolean isServerConfigured()
     {
         return false;
     }
 
-    default <T> T post(String path, String payload, ThrowingFunction<InputStream, T> consumer)
+    default <T> T post(String path, String payload, String contentType, ThrowingFunction<InputStream, T> consumer)
     {
-        return post(path, payload, "application/json", consumer);
+        return post(path, payload, contentType, consumer, NO_CANCEL_LISTENER);
     }
 
-    <T> T post(String path, String payload, String contentType, ThrowingFunction<InputStream, T> consumer);
+    <T> T post(String path, String payload, String contentType, ThrowingFunction<InputStream, T> consumer, Consumer<Runnable> cancelListener);
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/connection/ConnectionLSPGrammarExtension.java
@@ -33,6 +33,7 @@ import org.finos.legend.engine.ide.lsp.extension.SourceInformationUtil;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult.Type;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
@@ -90,9 +91,9 @@ public class ConnectionLSPGrammarExtension extends AbstractLegacyParserLSPGramma
     }
 
     @Override
-    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams)
+    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams, CancellationToken requestId)
     {
-        return GENERATE_DB_COMMAND_ID.equals(commandId) ? generateDBFromConnection(section, entityPath) : super.execute(section, entityPath, commandId, executableArgs, Map.of());
+        return GENERATE_DB_COMMAND_ID.equals(commandId) ? generateDBFromConnection(section, entityPath) : super.execute(section, entityPath, commandId, executableArgs, Map.of(), requestId);
     }
 
     @Override

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/LegendTDSRequestHandlerImpl.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/LegendTDSRequestHandlerImpl.java
@@ -31,6 +31,7 @@ import org.finos.legend.engine.ide.lsp.extension.agGrid.TDSGroupBy;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.TDSRequest;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.features.LegendTDSRequestHandler;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
@@ -47,7 +48,7 @@ public class LegendTDSRequestHandlerImpl implements LegendTDSRequestHandler
     }
 
     @Override
-    public LegendExecutionResult executeLegendTDSRequest(SectionState section, String entityPath, TDSRequest request, Map<String, Object> inputParameters)
+    public LegendExecutionResult executeLegendTDSRequest(SectionState section, String entityPath, TDSRequest request, Map<String, Object> inputParameters, CancellationToken requestId)
     {
         if (!(section.getExtension() instanceof FunctionExecutionSupport))
         {
@@ -83,7 +84,7 @@ public class LegendTDSRequestHandlerImpl implements LegendTDSRequestHandler
 
             GlobalState globalState = section.getDocumentState().getGlobalState();
             SingleExecutionPlan executionPlan = functionExecutionSupport.getExecutionPlan(packageableElement, newLambda, pureModel, inputParameters, globalState.getSetting(Constants.LEGEND_PROTOCOL_VERSION));
-            FunctionExecutionSupport.executePlan(globalState, functionExecutionSupport, section.getDocumentState().getDocumentId(), section.getSectionNumber(), executionPlan, null, entityPath, inputParameters, results);
+            FunctionExecutionSupport.executePlan(globalState, functionExecutionSupport, section.getDocumentState().getDocumentId(), section.getSectionNumber(), executionPlan, null, entityPath, inputParameters, results, requestId);
         }
         catch (Exception e)
         {

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/mapping/MappingLSPGrammarExtension.java
@@ -31,6 +31,7 @@ import org.finos.legend.engine.ide.lsp.extension.*;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult.Type;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
@@ -157,7 +158,7 @@ public class MappingLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
     }
 
     @Override
-    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams)
+    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams, CancellationToken requestId)
     {
         switch (commandId)
         {
@@ -175,7 +176,7 @@ public class MappingLSPGrammarExtension extends AbstractLegacyParserLSPGrammarEx
             }
             default:
             {
-                return super.execute(section, entityPath, commandId, executableArgs, Map.of());
+                return super.execute(section, entityPath, commandId, executableArgs, Map.of(), requestId);
             }
         }
     }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/relational/RelationalLSPGrammarExtension.java
@@ -38,6 +38,7 @@ import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.mapping.MappingLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.mapping.MappingLSPGrammarProvider;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
@@ -203,9 +204,9 @@ public class RelationalLSPGrammarExtension extends AbstractSectionParserLSPGramm
     }
 
     @Override
-    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams)
+    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams, CancellationToken requestId)
     {
-        return GENERATE_MODEL_MAPPING_COMMAND_ID.equals(commandId) ? generateModelsFromDatabaseSpecification(section, entityPath) : super.execute(section, entityPath, commandId, executableArgs, Map.of());
+        return GENERATE_MODEL_MAPPING_COMMAND_ID.equals(commandId) ? generateModelsFromDatabaseSpecification(section, entityPath) : super.execute(section, entityPath, commandId, executableArgs, Map.of(), requestId);
     }
 
     private Iterable<? extends LegendExecutionResult> generateModelsFromDatabaseSpecification(SectionState section, String entityPath)

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/service/ServiceLSPGrammarExtension.java
@@ -55,6 +55,7 @@ import org.finos.legend.engine.ide.lsp.extension.core.PureLSPGrammarExtension;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult.Type;
 import org.finos.legend.engine.ide.lsp.extension.runtime.RuntimeLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
@@ -289,7 +290,7 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
     }
 
     @Override
-    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams)
+    public Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParams, CancellationToken requestId)
     {
         switch (commandId)
         {
@@ -303,7 +304,7 @@ public class ServiceLSPGrammarExtension extends AbstractSectionParserLSPGrammarE
             }
             default:
             {
-                return FunctionExecutionSupport.execute(this, section, entityPath, commandId, executableArgs, inputParams);
+                return FunctionExecutionSupport.execute(this, section, entityPath, commandId, executableArgs, inputParams, requestId);
             }
         }
     }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/AbstractLSPGrammarExtensionTest.java
@@ -110,22 +110,22 @@ public abstract class AbstractLSPGrammarExtensionTest<T extends LegendLSPGrammar
     protected Iterable<? extends LegendExecutionResult> testCommand(String code, String entityPath, String command)
     {
         SectionState sectionState = stateForTestFactory.newSectionState(DOC_ID_FOR_TEXT, code);
-        return this.extension.execute(sectionState, entityPath, command, Map.of(), Map.of());
+        return this.extension.execute(sectionState, entityPath, command, Map.of(), Map.of(), sectionState.getDocumentState().getGlobalState().cancellationToken("test"));
     }
 
     protected Iterable<? extends LegendExecutionResult> testCommand(SectionState sectionState, String entityPath, String command)
     {
-        return this.extension.execute(sectionState, entityPath, command, Map.of(), Map.of());
+        return this.extension.execute(sectionState, entityPath, command, Map.of(), Map.of(), sectionState.getDocumentState().getGlobalState().cancellationToken("test"));
     }
 
     protected Iterable<? extends LegendExecutionResult> testCommand(SectionState sectionState, String entityPath, String command, Map<String, String> executableArgs)
     {
-        return this.extension.execute(sectionState, entityPath, command, executableArgs, Map.of());
+        return this.extension.execute(sectionState, entityPath, command, executableArgs, Map.of(), sectionState.getDocumentState().getGlobalState().cancellationToken("test"));
     }
 
     protected Iterable<? extends LegendExecutionResult> testCommand(SectionState sectionState, String entityPath, String command, Map<String, String> executableArgs, Map<String, Object> inputParams)
     {
-        return this.extension.execute(sectionState, entityPath, command, executableArgs, inputParams);
+        return this.extension.execute(sectionState, entityPath, command, executableArgs, inputParams, sectionState.getDocumentState().getGlobalState().cancellationToken("test"));
     }
 
     protected SectionState newSectionState(String docId, String text)

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/StateForTestFactory.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/StateForTestFactory.java
@@ -19,6 +19,7 @@ package org.finos.legend.engine.ide.lsp.extension;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -27,6 +28,8 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.map.mutable.ConcurrentHashMap;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.NotebookDocumentState;
@@ -245,6 +248,7 @@ public class StateForTestFactory
     private class TestGlobalState extends AbstractState implements GlobalState
     {
         private final MutableMap<String, DocumentState> docStates = Maps.mutable.empty();
+        private final Map<String, CancellationToken> cancellationTokens = new ConcurrentHashMap<>();
 
         @Override
         public DocumentState getDocumentState(String id)
@@ -278,6 +282,12 @@ public class StateForTestFactory
                 return "vX_X_X";
             }
             return null;
+        }
+
+        @Override
+        public CancellationToken cancellationToken(String requestId)
+        {
+            return this.cancellationTokens.computeIfAbsent(requestId, x -> new CancellationToken(x, this.cancellationTokens::remove));
         }
     }
 

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/LegendLSPGrammarExtension.java
@@ -26,6 +26,7 @@ import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendCommand;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.extension.reference.LegendReference;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.test.LegendTest;
@@ -139,7 +140,7 @@ public interface LegendLSPGrammarExtension extends LegendLSPExtension
      * @param inputParameters input Parameters
      * @return execution results
      */
-    default Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParameters)
+    default Iterable<? extends LegendExecutionResult> execute(SectionState section, String entityPath, String commandId, Map<String, String> executableArgs, Map<String, Object> inputParameters, CancellationToken requestId)
     {
         return Collections.emptyList();
     }

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendTDSRequestHandler.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/features/LegendTDSRequestHandler.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPFeature;
 import org.finos.legend.engine.ide.lsp.extension.agGrid.TDSRequest;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 
 public interface LegendTDSRequestHandler extends LegendLSPFeature
@@ -27,11 +28,12 @@ public interface LegendTDSRequestHandler extends LegendLSPFeature
     /**
      * Return the Legend execution result for the given tds request by client.
      *
-     * @param section grammar section state
-     * @param entityPath the function entity path
-     * @param request the ag-grid tds request
+     * @param section         grammar section state
+     * @param entityPath      the function entity path
+     * @param request         the ag-grid tds request
      * @param inputParameters input parameters to the function
+     * @param requestId request id in the form of cancellation token to allow expensive operations on this request to be cancelled
      * @return Legend execution result
      */
-    LegendExecutionResult executeLegendTDSRequest(SectionState section, String entityPath, TDSRequest request, Map<String, Object> inputParameters);
+    LegendExecutionResult executeLegendTDSRequest(SectionState section, String entityPath, TDSRequest request, Map<String, Object> inputParameters, CancellationToken requestId);
 }

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/state/CancellationToken.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/state/CancellationToken.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.extension.state;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public final class CancellationToken implements AutoCloseable
+{
+    private final String id;
+    private final Consumer<String> onClose;
+    private boolean cancelled = false;
+    private final List<CancellationListener> cancelListeners = new ArrayList<>();
+
+    public CancellationToken(String id, Consumer<String> onClose)
+    {
+        this.id = id;
+        this.onClose = onClose;
+    }
+
+    public String getId()
+    {
+        return this.id;
+    }
+
+    public synchronized void listener(CancellationListener toRunOnCancel)
+    {
+        if (this.cancelled)
+        {
+            this.notify(toRunOnCancel);
+        }
+        else
+        {
+            this.cancelListeners.add(toRunOnCancel);
+        }
+    }
+
+    public synchronized void cancel()
+    {
+        this.cancelled = true;
+        this.cancelListeners.forEach(this::notify);
+    }
+
+    private void notify(CancellationListener runnable)
+    {
+        try
+        {
+            runnable.cancel();
+        }
+        catch (Throwable ignore)
+        {
+            // ignore
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        this.onClose.accept(this.id);
+    }
+
+    public synchronized boolean isCancelled()
+    {
+        return this.cancelled;
+    }
+
+    public interface CancellationListener
+    {
+        void cancel() throws Exception;
+    }
+}

--- a/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/state/GlobalState.java
+++ b/legend-engine-ide-lsp-extension-api/src/main/java/org/finos/legend/engine/ide/lsp/extension/state/GlobalState.java
@@ -99,7 +99,7 @@ public interface GlobalState extends State
             };
             forkJoinWorkerThread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
             return forkJoinWorkerThread;
-        }, null,  false);
+        }, null, false);
     }
 
     /**
@@ -109,4 +109,6 @@ public interface GlobalState extends State
      * @return setting value or null
      */
     String getSetting(String key);
+
+    CancellationToken cancellationToken(String requestId);
 }

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/commands/LegendCancelCommandExecutionHandler.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/commands/LegendCancelCommandExecutionHandler.java
@@ -16,33 +16,34 @@
 
 package org.finos.legend.engine.ide.lsp.commands;
 
-import java.util.UUID;
+import java.util.List;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
 import org.finos.legend.engine.ide.lsp.server.LegendLanguageServer;
 
-public class LegendCommandExecutionHandler implements CommandExecutionHandler
+public class LegendCancelCommandExecutionHandler implements CommandExecutionHandler
 {
-    public static final String LEGEND_COMMAND_ID = "legend.command";
+    public static final String LEGEND_CANCEL_COMMAND_ID = "legend.cancel.command";
 
-    private final LegendCommandV2ExecutionHandler impl;
+    private final LegendLanguageServer server;
 
-    public LegendCommandExecutionHandler(LegendLanguageServer server)
+    public LegendCancelCommandExecutionHandler(LegendLanguageServer server)
     {
-        this.impl = new LegendCommandV2ExecutionHandler(server);
+        this.server = server;
     }
 
     @Override
     public String getCommandId()
     {
-        return LEGEND_COMMAND_ID;
+        return LEGEND_CANCEL_COMMAND_ID;
     }
 
     @Override
     public Iterable<? extends LegendExecutionResult> executeCommand(Either<String, Integer> progressToken, ExecuteCommandParams params)
     {
-        params.getArguments().add(0, UUID.randomUUID().toString());
-        return this.impl.executeCommand(progressToken, params);
+        String requestId = this.server.extractValueAs(params.getArguments().get(0), String.class);
+        this.server.getGlobalState().cancellationToken(requestId).cancel();
+        return List.of();
     }
 }

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/commands/LegendCommandV2ExecutionHandler.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/commands/LegendCommandV2ExecutionHandler.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2024 Goldman Sachs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.finos.legend.engine.ide.lsp.commands;
+
+import com.google.gson.JsonObject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
+import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
+import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
+import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
+import org.finos.legend.engine.ide.lsp.extension.text.TextLocation;
+import org.finos.legend.engine.ide.lsp.extension.text.TextPosition;
+import org.finos.legend.engine.ide.lsp.server.LegendLanguageServer;
+
+public class LegendCommandV2ExecutionHandler implements CommandExecutionHandler
+{
+    public static final String LEGEND_COMMAND_V2_ID = "legend.command.v2";
+
+    private final LegendLanguageServer server;
+
+    public LegendCommandV2ExecutionHandler(LegendLanguageServer server)
+    {
+        this.server = server;
+    }
+
+    @Override
+    public String getCommandId()
+    {
+        return LEGEND_COMMAND_V2_ID;
+    }
+
+    @Override
+    public Iterable<? extends LegendExecutionResult> executeCommand(Either<String, Integer> progressToken, ExecuteCommandParams params)
+    {
+        String requestId = this.server.extractValueAs(params.getArguments().get(0), String.class);
+        try (CancellationToken token = this.server.getGlobalState().cancellationToken(requestId))
+        {
+            return this.executeCommand(progressToken, params, token);
+        }
+    }
+
+    private Iterable<? extends LegendExecutionResult> executeCommand(Either<String, Integer> progressToken, ExecuteCommandParams params, CancellationToken token)
+    {
+        List<Object> args = params.getArguments();
+
+        if (args.get(1) instanceof JsonObject)
+        {
+            return this.executeCommandWithTextLocation(progressToken, args, token);
+        }
+        else
+        {
+            return this.executeCommandWithDocumentAndSection(progressToken, args, token);
+        }
+    }
+
+    private Iterable<? extends LegendExecutionResult> executeCommandWithDocumentAndSection(Either<String, Integer> progressToken, List<Object> args, CancellationToken cancellationToken)
+    {
+        String uri = this.server.extractValueAs(args.get(1), String.class);
+        int section = this.server.extractValueAs(args.get(2), Integer.class);
+        String entity = this.server.extractValueAs(args.get(3), String.class);
+        String id = this.server.extractValueAs(args.get(4), String.class);
+        Map<String, String> executableArgs = ((args.size() < 6) || (args.get(5) == null)) ? Collections.emptyMap() : this.server.extractValueAsMap(args.get(5), String.class, String.class);
+        Map<String, Object> inputParameters = ((args.size() < 7) || (args.get(6) == null)) ? Collections.emptyMap() : this.server.extractValueAsMap(args.get(6), String.class, Object.class);
+
+        return this.server.runAndFireEvent(id, () ->
+        {
+            Iterable<? extends LegendExecutionResult> results;
+
+            this.server.notifyBegin(progressToken, entity);
+
+            GlobalState globalState = this.server.getGlobalState();
+            DocumentState docState = globalState.getDocumentState(uri);
+            if (docState == null)
+            {
+                throw new RuntimeException("Unknown document: " + uri);
+            }
+
+            SectionState sectionState = docState.getSectionState(section);
+            LegendLSPGrammarExtension extension = sectionState.getExtension();
+            if (extension == null)
+            {
+                throw new RuntimeException("Could not execute command " + id + " for entity " + entity + " in section " + sectionState.getSectionNumber() + " of " + uri + ": no extension found");
+            }
+
+            try
+            {
+                results = extension.execute(sectionState, entity, id, executableArgs, inputParameters, cancellationToken);
+            }
+            catch (Throwable e)
+            {
+                String message = "Command execution " + id + " for entity " + entity + " in section " + sectionState.getSectionNumber() + " of " + uri + " failed.";
+                results = Collections.singletonList(LegendExecutionResult.errorResult(new Exception(message, e), message, entity, null));
+            }
+
+            return results;
+        });
+    }
+
+    private Iterable<? extends LegendExecutionResult> executeCommandWithTextLocation(Either<String, Integer> progressToken, List<Object> args, CancellationToken cancellationToken)
+    {
+        TextLocation textLocation = this.server.extractValueAs(args.get(1), TextLocation.class);
+        String id = this.server.extractValueAs(args.get(2), String.class);
+        Map<String, String> executableArgs = ((args.size() < 4) || (args.get(3) == null)) ? Collections.emptyMap() : this.server.extractValueAsMap(args.get(3), String.class, String.class);
+        Map<String, Object> inputParameters = ((args.size() < 5) || (args.get(4) == null)) ? Collections.emptyMap() : this.server.extractValueAsMap(args.get(4), String.class, Object.class);
+
+        String uri = textLocation.getDocumentId();
+
+        return this.server.runAndFireEvent(id, () ->
+        {
+            Iterable<? extends LegendExecutionResult> results;
+
+            GlobalState globalState = this.server.getGlobalState();
+            DocumentState docState = globalState.getDocumentState(uri);
+            if (docState == null)
+            {
+                throw new RuntimeException("Unknown document: " + uri);
+            }
+
+            TextPosition start = textLocation.getTextInterval().getStart();
+            SectionState sectionState = docState.getSectionStateAtLine(start.getLine());
+            LegendLSPGrammarExtension extension = sectionState.getExtension();
+            if (extension == null)
+            {
+                throw new RuntimeException("Could not execute command " + id + " @ " + textLocation + ": no extension found");
+            }
+
+            String entity = extension.getDeclaration(sectionState, start).orElseThrow(() -> new RuntimeException("Could not execute command " + id + " @ " + textLocation + ": no entity found")).getIdentifier();
+
+            this.server.notifyBegin(progressToken, entity);
+
+            try
+            {
+                results = extension.execute(sectionState, entity, id, executableArgs, inputParameters, cancellationToken);
+            }
+            catch (Throwable e)
+            {
+                String message = "Command execution " + id + " for entity " + entity + " in section " + sectionState.getSectionNumber() + " of " + uri + " failed.";
+                results = Collections.singletonList(LegendExecutionResult.errorResult(new Exception(message, e), message, entity, null));
+            }
+
+            return results;
+        });
+    }
+}

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageService.java
@@ -24,6 +24,7 @@ import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult
 import org.finos.legend.engine.ide.lsp.extension.features.LegendSDLCFeature;
 import org.finos.legend.engine.ide.lsp.extension.features.LegendTDSRequestHandler;
 import org.finos.legend.engine.ide.lsp.extension.features.LegendVirtualFileSystemContentInitializer;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
 import org.finos.legend.engine.ide.lsp.extension.state.SectionState;
 import org.finos.legend.engine.ide.lsp.extension.test.LegendTest;
@@ -77,6 +78,7 @@ public class LegendLanguageService implements LegendLanguageServiceContract
                     String uri = request.getUri();
                     int sectionNum = request.getSectionNum();
                     String entity = request.getEntity();
+                    CancellationToken requestId = this.server.getGlobalState().cancellationToken(Optional.ofNullable(request.getId()).orElseGet(() -> UUID.randomUUID().toString()));
                     DocumentState docState = globalState.getDocumentState(uri);
                     if (docState == null)
                     {
@@ -88,7 +90,7 @@ public class LegendLanguageService implements LegendLanguageServiceContract
                     {
                         LegendTDSRequestHandler handler = globalState.findFeatureThatImplements(LegendTDSRequestHandler.class).findAny().orElseThrow(() -> new RuntimeException("Could not execute legend TDS request for entity " + entity + " in section " + sectionNum + " of " + uri + ": no extension found"));
                         SectionState sectionState = docState.getSectionState(sectionNum);
-                        result = handler.executeLegendTDSRequest(sectionState, entity, request.getRequest(), request.getInputParameters());
+                        result = handler.executeLegendTDSRequest(sectionState, entity, request.getRequest(), request.getInputParameters(), requestId);
                     }
                     catch (Throwable e)
                     {

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendServerGlobalState.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendServerGlobalState.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPFeature;
 import org.finos.legend.engine.ide.lsp.extension.LegendLSPGrammarExtension;
+import org.finos.legend.engine.ide.lsp.extension.state.CancellationToken;
 import org.finos.legend.engine.ide.lsp.extension.state.DocumentState;
 import org.finos.legend.engine.ide.lsp.extension.state.GlobalState;
 import org.finos.legend.engine.ide.lsp.extension.state.NotebookDocumentState;
@@ -47,6 +48,7 @@ public class LegendServerGlobalState extends AbstractState implements GlobalStat
     private static final Logger LOGGER = LoggerFactory.getLogger(LegendServerGlobalState.class);
 
     private final Map<String, LegendServerDocumentState> docs = new ConcurrentHashMap<>();
+    private final Map<String, CancellationToken> cancellationTokens = new ConcurrentHashMap<>();
     private final LegendLanguageServer server;
 
     LegendServerGlobalState(LegendLanguageServer server)
@@ -193,6 +195,12 @@ public class LegendServerGlobalState extends AbstractState implements GlobalStat
     public String getSetting(String key)
     {
         return this.server.getSetting(key);
+    }
+
+    @Override
+    public CancellationToken cancellationToken(String requestId)
+    {
+        return this.cancellationTokens.computeIfAbsent(requestId, x -> new CancellationToken(x, this.cancellationTokens::remove));
     }
 
     static class LegendServerDocumentState extends AbstractState implements DocumentState

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
@@ -122,20 +122,7 @@ public class LegendWorkspaceService implements WorkspaceService
                     switch (result.getType())
                     {
                         case SUCCESS:
-                        {
-                            String message = result.getMessage();
-                            String logMessage = result.getLogMessage();
-                            if ((logMessage == null) || logMessage.equals(message))
-                            {
-                                this.server.logInfoToClient(message);
-                            }
-                            else
-                            {
-                                this.server.showInfoToClient(message);
-                                this.server.logInfoToClient(logMessage);
-                            }
                             break;
-                        }
                         case FAILURE:
                         case WARNING:
                         {

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendWorkspaceService.java
@@ -47,7 +47,9 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.finos.legend.engine.ide.lsp.commands.CommandExecutionHandler;
+import org.finos.legend.engine.ide.lsp.commands.LegendCancelCommandExecutionHandler;
 import org.finos.legend.engine.ide.lsp.commands.LegendCommandExecutionHandler;
+import org.finos.legend.engine.ide.lsp.commands.LegendCommandV2ExecutionHandler;
 import org.finos.legend.engine.ide.lsp.extension.declaration.LegendDeclaration;
 import org.finos.legend.engine.ide.lsp.extension.diagnostic.LegendDiagnostic;
 import org.finos.legend.engine.ide.lsp.extension.execution.LegendExecutionResult;
@@ -67,6 +69,8 @@ public class LegendWorkspaceService implements WorkspaceService
     {
         this.server = server;
         this.addCommandExecutionHandler(new LegendCommandExecutionHandler(server));
+        this.addCommandExecutionHandler(new LegendCommandV2ExecutionHandler(server));
+        this.addCommandExecutionHandler(new LegendCancelCommandExecutionHandler(server));
     }
 
     private void addCommandExecutionHandler(CommandExecutionHandler legendCommandExecutionHandler)

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/service/FunctionTDSRequest.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/service/FunctionTDSRequest.java
@@ -27,12 +27,14 @@ public class FunctionTDSRequest
     private final String uri;
     private final int sectionNum;
     private final String entity;
+    private final String id;
     @JsonAdapter(LegendTypeAdapterFactory.class)
     private TDSRequest request;
     private Map<String, Object> inputParameters;
 
-    public FunctionTDSRequest(String uri, int sectionNum, String entity, TDSRequest request, Map<String, Object> inputParameters)
+    public FunctionTDSRequest(String id, String uri, int sectionNum, String entity, TDSRequest request, Map<String, Object> inputParameters)
     {
+        this.id = id;
         this.uri = Objects.requireNonNull(uri);
         this.sectionNum = Objects.requireNonNull(sectionNum);
         this.entity = Objects.requireNonNull(entity);
@@ -88,5 +90,10 @@ public class FunctionTDSRequest
     public Map<String, Object> getInputParameters()
     {
         return inputParameters;
+    }
+
+    public String getId()
+    {
+        return this.id;
     }
 }

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerFunctionExecutionIntegration.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerFunctionExecutionIntegration.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -269,7 +270,7 @@ public class TestLegendLanguageServerFunctionExecutionIntegration
         List<TDSAggregation> aggregations = new ArrayList<>();
         TDSGroupBy groupBy = new TDSGroupBy(groupByColumns, groupKeys, aggregations);
         TDSRequest request = new TDSRequest(0, 0, columns, filter, sort, groupBy);
-        FunctionTDSRequest functionTDSRequest = new FunctionTDSRequest(uri, sectionNum, entity, request, Collections.emptyMap());
+        FunctionTDSRequest functionTDSRequest = new FunctionTDSRequest(UUID.randomUUID().toString(), uri, sectionNum, entity, request, Collections.emptyMap());
 
         // No push down operations
         Object resultObject = extension.futureGet(legendLanguageService.legendTDSRequest(functionTDSRequest));


### PR DESCRIPTION
This adds the support for a cancel flow, where user request could be cancelled before these request completes.

This introduce a new "legend command" (v2) that expects a request id.  This id is used to create and register a cancellation token.

This also introduce a new "cancel" command that will flag to the token that the user requested to cancel the request.

Command implementors can register different IO actions to the cancellation token, so that if the request is cancelled, the IO can be interrupted.

The main use case for this is to allow users to stop long running relational queries.

 