### PR TITLE
Add functionality to filter entities request by paths

### DIFF
--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageService.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/LegendLanguageService.java
@@ -251,7 +251,13 @@ public class LegendLanguageService implements LegendLanguageServiceContract
                 LegendLSPGrammarExtension extension = sectionState.getExtension();
                 if (extension != null)
                 {
-                    extension.getEntities(sectionState).forEach(entities::add);
+                    extension.getEntities(sectionState).forEach(entity ->
+                    {
+                        if (request.getEntityPaths().isEmpty() || request.getEntityPaths().contains(entity.getPath()))
+                        {
+                            entities.add(entity);
+                        }
+                    });
                 }
             });
 

--- a/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/request/LegendEntitiesRequest.java
+++ b/legend-engine-ide-lsp-server/src/main/java/org/finos/legend/engine/ide/lsp/server/request/LegendEntitiesRequest.java
@@ -26,14 +26,18 @@ public class LegendEntitiesRequest
     @NonNull
     private List<TextDocumentIdentifier> textDocuments;
 
+    @NonNull
+    private List<String> entityPaths;
+
     public LegendEntitiesRequest()
     {
-        this(List.of());
+        this(List.of(), List.of());
     }
 
-    public LegendEntitiesRequest(@NonNull List<TextDocumentIdentifier> textDocuments)
+    public LegendEntitiesRequest(@NonNull List<TextDocumentIdentifier> textDocuments, @NonNull List<String> entityPaths)
     {
         this.setTextDocuments(textDocuments);
+        this.setEntityPaths(entityPaths);
     }
 
     public List<TextDocumentIdentifier> getTextDocuments()
@@ -44,5 +48,15 @@ public class LegendEntitiesRequest
     public void setTextDocuments(@NonNull List<TextDocumentIdentifier> textDocument)
     {
         this.textDocuments = Preconditions.checkNotNull(textDocument, "textDocuments");
+    }
+
+    public List<String> getEntityPaths()
+    {
+        return this.entityPaths;
+    }
+
+    public void setEntityPaths(@NonNull List<String> entityPaths)
+    {
+        this.entityPaths = Preconditions.checkNotNull(entityPaths, "entityPaths");
     }
 }

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerFunctionExecutionIntegration.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerFunctionExecutionIntegration.java
@@ -235,7 +235,7 @@ public class TestLegendLanguageServerFunctionExecutionIntegration
     {
         Path path = extension.addToWorkspace("file1.pure", code);
 
-        List<LegendEntity> entities = extension.futureGet(extension.getServer().getLegendLanguageService().entities(new LegendEntitiesRequest(List.of(new TextDocumentIdentifier(path.toUri().toString())))));
+        List<LegendEntity> entities = extension.futureGet(extension.getServer().getLegendLanguageService().entities(new LegendEntitiesRequest(List.of(new TextDocumentIdentifier(path.toUri().toString())), List.of())));
 
         Assertions.assertEquals(1, entities.size());
 

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerIntegration.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerIntegration.java
@@ -1152,7 +1152,8 @@ public class TestLegendLanguageServerIntegration
                                 List.of(
                                         new TextDocumentIdentifier(enumPath.toUri().toString()),
                                         new TextDocumentIdentifier(file1Path.toUri().toString())
-                                )
+                                ),
+                                List.of()
                         )
                 )
         );

--- a/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerIntegration.java
+++ b/legend-engine-ide-lsp-server/src/test/java/org/finos/legend/engine/ide/lsp/server/integration/TestLegendLanguageServerIntegration.java
@@ -1456,6 +1456,273 @@ public class TestLegendLanguageServerIntegration
                 jsonPerFile,
                 jsonAssertConfig
         );
+
+        List<LegendEntity> entitiesPerPath = extension.futureGet(extension.getServer().getLegendLanguageService().entities(
+                        new LegendEntitiesRequest(
+                                List.of(),
+                                List.of("abc::abc", "xyz::abc")
+                        )
+                )
+        );
+
+        Assertions.assertEquals(2, entitiesPerPath.size());
+        entitiesPerPath.sort(Comparator.comparing(LegendEntity::getPath));
+        String jsonPerPath = new Gson().toJson(entitiesPerPath);
+
+        JsonAssert.assertJsonEquals(
+                "[\n" +
+                        "  {\n" +
+                        "    \"path\": \"abc::abc\",\n" +
+                        "    \"classifierPath\": \"meta::pure::metamodel::type::Class\",\n" +
+                        "    \"content\": {\n" +
+                        "      \"_type\": \"class\",\n" +
+                        "      \"name\": \"abc\",\n" +
+                        "      \"sourceInformation\": {\n" +
+                        "        \"sourceId\": \"\",\n" +
+                        "        \"startLine\": 2.0,\n" +
+                        "        \"startColumn\": 1.0,\n" +
+                        "        \"endLine\": 5.0,\n" +
+                        "        \"endColumn\": 1.0\n" +
+                        "      },\n" +
+                        "      \"superTypes\": [],\n" +
+                        "      \"originalMilestonedProperties\": [],\n" +
+                        "      \"properties\": [\n" +
+                        "        {\n" +
+                        "          \"name\": \"abc\",\n" +
+                        "          \"genericType\": {\n" +
+                        "            \"rawType\": {\n" +
+                        "              \"_type\": \"packageableType\",\n" +
+                        "              \"sourceInformation\": {\n" +
+                        "                \"sourceId\": \"\",\n" +
+                        "                \"startLine\": 4.0,\n" +
+                        "                \"startColumn\": 8.0,\n" +
+                        "                \"endLine\": 4.0,\n" +
+                        "                \"endColumn\": 13.0\n" +
+                        "              },\n" +
+                        "              \"fullPath\": \"String\"\n" +
+                        "            },\n" +
+                        "            \"typeArguments\": [],\n" +
+                        "            \"multiplicityArguments\": [],\n" +
+                        "            \"typeVariableValues\": []\n" +
+                        "          },\n" +
+                        "          \"multiplicity\": {\n" +
+                        "            \"lowerBound\": 1.0,\n" +
+                        "            \"upperBound\": 1.0\n" +
+                        "          },\n" +
+                        "          \"stereotypes\": [],\n" +
+                        "          \"taggedValues\": [],\n" +
+                        "          \"sourceInformation\": {\n" +
+                        "            \"sourceId\": \"\",\n" +
+                        "            \"startLine\": 4.0,\n" +
+                        "            \"startColumn\": 3.0,\n" +
+                        "            \"endLine\": 4.0,\n" +
+                        "            \"endColumn\": 17.0\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      ],\n" +
+                        "      \"qualifiedProperties\": [],\n" +
+                        "      \"stereotypes\": [],\n" +
+                        "      \"taggedValues\": [],\n" +
+                        "      \"constraints\": [],\n" +
+                        "      \"package\": \"abc\"\n" +
+                        "    },\n" +
+                        "    \"location\": {\n" +
+                        "      \"documentId\": \"\",\n" +
+                        "      \"textInterval\": {\n" +
+                        "        \"start\": {\n" +
+                        "          \"line\": 1,\n" +
+                        "          \"column\": 0\n" +
+                        "        },\n" +
+                        "        \"end\": {\n" +
+                        "          \"line\": 4,\n" +
+                        "          \"column\": 0\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  },\n" +
+                        "  {\n" +
+                        "    \"path\": \"xyz::abc\",\n" +
+                        "    \"classifierPath\": \"meta::pure::metamodel::type::Class\",\n" +
+                        "    \"content\": {\n" +
+                        "      \"_type\": \"class\",\n" +
+                        "      \"name\": \"abc\",\n" +
+                        "      \"sourceInformation\": {\n" +
+                        "        \"sourceId\": \"\",\n" +
+                        "        \"startLine\": 2.0,\n" +
+                        "        \"startColumn\": 1.0,\n" +
+                        "        \"endLine\": 5.0,\n" +
+                        "        \"endColumn\": 1.0\n" +
+                        "      },\n" +
+                        "      \"superTypes\": [],\n" +
+                        "      \"originalMilestonedProperties\": [],\n" +
+                        "      \"properties\": [\n" +
+                        "        {\n" +
+                        "          \"name\": \"abc\",\n" +
+                        "          \"genericType\": {\n" +
+                        "            \"rawType\": {\n" +
+                        "              \"_type\": \"packageableType\",\n" +
+                        "              \"sourceInformation\": {\n" +
+                        "                \"sourceId\": \"\",\n" +
+                        "                \"startLine\": 4.0,\n" +
+                        "                \"startColumn\": 8.0,\n" +
+                        "                \"endLine\": 4.0,\n" +
+                        "                \"endColumn\": 13.0\n" +
+                        "              },\n" +
+                        "              \"fullPath\": \"String\"\n" +
+                        "            },\n" +
+                        "            \"typeArguments\": [],\n" +
+                        "            \"multiplicityArguments\": [],\n" +
+                        "            \"typeVariableValues\": []\n" +
+                        "          },\n" +
+                        "          \"multiplicity\": {\n" +
+                        "            \"lowerBound\": 1.0,\n" +
+                        "            \"upperBound\": 1.0\n" +
+                        "          },\n" +
+                        "          \"stereotypes\": [],\n" +
+                        "          \"taggedValues\": [],\n" +
+                        "          \"sourceInformation\": {\n" +
+                        "            \"sourceId\": \"\",\n" +
+                        "            \"startLine\": 4.0,\n" +
+                        "            \"startColumn\": 3.0,\n" +
+                        "            \"endLine\": 4.0,\n" +
+                        "            \"endColumn\": 17.0\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      ],\n" +
+                        "      \"qualifiedProperties\": [],\n" +
+                        "      \"stereotypes\": [],\n" +
+                        "      \"taggedValues\": [],\n" +
+                        "      \"constraints\": [],\n" +
+                        "      \"package\": \"xyz\"\n" +
+                        "    },\n" +
+                        "    \"location\": {\n" +
+                        "      \"documentId\": \"\",\n" +
+                        "      \"textInterval\": {\n" +
+                        "        \"start\": {\n" +
+                        "          \"line\": 1,\n" +
+                        "          \"column\": 0\n" +
+                        "        },\n" +
+                        "        \"end\": {\n" +
+                        "          \"line\": 4,\n" +
+                        "          \"column\": 0\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "]",
+                jsonPerPath,
+                jsonAssertConfig
+        );
+
+        List<LegendEntity> entitiesPerFileAndPath = extension.futureGet(extension.getServer().getLegendLanguageService().entities(
+                        new LegendEntitiesRequest(
+                                List.of(
+                                        new TextDocumentIdentifier(file1Path.toUri().toString())
+                                ),
+                                List.of("abc::abc", "xyz::abc")
+                        )
+                )
+        );
+
+        Assertions.assertEquals(1, entitiesPerFileAndPath.size());
+        entitiesPerFileAndPath.sort(Comparator.comparing(LegendEntity::getPath));
+        String jsonPerFileAndPath = new Gson().toJson(entitiesPerFileAndPath);
+
+        JsonAssert.assertJsonEquals(
+                "[\n" +
+                        "  {\n" +
+                        "    \"path\": \"abc::abc\",\n" +
+                        "    \"classifierPath\": \"meta::pure::metamodel::type::Class\",\n" +
+                        "    \"content\": {\n" +
+                        "      \"_type\": \"class\",\n" +
+                        "      \"name\": \"abc\",\n" +
+                        "      \"sourceInformation\": {\n" +
+                        "        \"sourceId\": \"\",\n" +
+                        "        \"startLine\": 2.0,\n" +
+                        "        \"startColumn\": 1.0,\n" +
+                        "        \"endLine\": 5.0,\n" +
+                        "        \"endColumn\": 1.0\n" +
+                        "      },\n" +
+                        "      \"superTypes\": [],\n" +
+                        "      \"originalMilestonedProperties\": [],\n" +
+                        "      \"properties\": [\n" +
+                        "        {\n" +
+                        "          \"name\": \"abc\",\n" +
+                        "          \"genericType\": {\n" +
+                        "            \"rawType\": {\n" +
+                        "              \"_type\": \"packageableType\",\n" +
+                        "              \"sourceInformation\": {\n" +
+                        "                \"sourceId\": \"\",\n" +
+                        "                \"startLine\": 4.0,\n" +
+                        "                \"startColumn\": 8.0,\n" +
+                        "                \"endLine\": 4.0,\n" +
+                        "                \"endColumn\": 13.0\n" +
+                        "              },\n" +
+                        "              \"fullPath\": \"String\"\n" +
+                        "            },\n" +
+                        "            \"typeArguments\": [],\n" +
+                        "            \"multiplicityArguments\": [],\n" +
+                        "            \"typeVariableValues\": []\n" +
+                        "          },\n" +
+                        "          \"multiplicity\": {\n" +
+                        "            \"lowerBound\": 1.0,\n" +
+                        "            \"upperBound\": 1.0\n" +
+                        "          },\n" +
+                        "          \"stereotypes\": [],\n" +
+                        "          \"taggedValues\": [],\n" +
+                        "          \"sourceInformation\": {\n" +
+                        "            \"sourceId\": \"\",\n" +
+                        "            \"startLine\": 4.0,\n" +
+                        "            \"startColumn\": 3.0,\n" +
+                        "            \"endLine\": 4.0,\n" +
+                        "            \"endColumn\": 17.0\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      ],\n" +
+                        "      \"qualifiedProperties\": [],\n" +
+                        "      \"stereotypes\": [],\n" +
+                        "      \"taggedValues\": [],\n" +
+                        "      \"constraints\": [],\n" +
+                        "      \"package\": \"abc\"\n" +
+                        "    },\n" +
+                        "    \"location\": {\n" +
+                        "      \"documentId\": \"\",\n" +
+                        "      \"textInterval\": {\n" +
+                        "        \"start\": {\n" +
+                        "          \"line\": 1,\n" +
+                        "          \"column\": 0\n" +
+                        "        },\n" +
+                        "        \"end\": {\n" +
+                        "          \"line\": 4,\n" +
+                        "          \"column\": 0\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "]",
+                jsonPerFileAndPath,
+                jsonAssertConfig
+        );
+
+        List<LegendEntity> entitiesPerFileAndPathNoMatch = extension.futureGet(extension.getServer().getLegendLanguageService().entities(
+                        new LegendEntitiesRequest(
+                                List.of(
+                                        new TextDocumentIdentifier(file1Path.toUri().toString())
+                                ),
+                                List.of("xyz::abc")
+                        )
+                )
+        );
+
+        Assertions.assertEquals(0, entitiesPerFileAndPathNoMatch.size());
+        entitiesPerFileAndPathNoMatch.sort(Comparator.comparing(LegendEntity::getPath));
+        String jsonPerFileAndPathNoMatch = new Gson().toJson(entitiesPerFileAndPathNoMatch);
+
+        JsonAssert.assertJsonEquals(
+                "[]",
+                jsonPerFileAndPathNoMatch,
+                jsonAssertConfig
+        );
     }
 
     @Test


### PR DESCRIPTION
Update entities request to also take an optional list of entity paths. If the list of entity paths is provided, then we filter the results of the entity request to only include entities in the provided list.