### PR TITLE
Add functionality to support DataCube in purebook

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
@@ -84,7 +84,6 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.domain.
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.runtime.Runtime;
 import org.finos.legend.engine.protocol.pure.v1.model.type.PackageableType;
 import org.finos.legend.engine.protocol.pure.v1.model.type.relationType.RelationType;
-import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.Variable;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.executionContext.ExecutionContext;
@@ -511,7 +510,7 @@ public interface FunctionExecutionSupport
             String typeName = Compiler.getLambdaReturnType(lambda, pureModel);
             Map<String, Object> result = new HashMap<>();
             result.put("returnType", typeName);
-            if (Objects.equals(typeName, "meta::pure::metamodel::relation::Relation"))
+            if (Objects.equals(typeName, "meta::pure::metamodel::relation::Relation") || Objects.equals(typeName, "meta::pure::store::RelationStoreAccessor"))
             {
                 RelationType relationType = Compiler.getLambdaRelationType(lambda, pureModel);
                 result.put("relationType", relationType);

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
@@ -293,8 +293,8 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
             return Lists.mutable.with(this.pureGrammarExtension.getExtension().errorResult(e, "Cannot generate an execution plan for given expression.  Likely the expression is not supported yet...", "notebook_cell", section.getDocumentState().getTextLocation()));
         }
 
-        boolean enableDatacube = Boolean.parseBoolean(executableArgs.getOrDefault("enableDatacube", "false"));
-        if (enableDatacube)
+        boolean enableDataCube = Boolean.parseBoolean(executableArgs.getOrDefault("enableDataCube", "false"));
+        if (enableDataCube)
         {
             GenericType lambdaReturnType = planGenerationResult.getLambdaFunction()._expressionSequence().getLast()._genericType()._typeArguments().getFirst();
             if (lambdaReturnType != null && lambdaReturnType._rawType() instanceof RelationType)

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
@@ -25,6 +25,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
@@ -65,9 +68,12 @@ import org.finos.legend.engine.repl.autocomplete.Completer;
 import org.finos.legend.engine.repl.autocomplete.CompleterExtension;
 import org.finos.legend.engine.repl.autocomplete.CompletionResult;
 import org.finos.legend.engine.repl.core.ReplExtension;
+import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.engine.shared.javaCompiler.JavaCompileException;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relation.RelationType;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.generics.GenericType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +88,8 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
     private PureLSPGrammarExtension pureGrammarExtension;
     private MutableList<ReplExtension> replExtensions;
     private MutableList<CompleterExtension> completerExtensions;
+    ObjectMapper objectMapper = ObjectMapperFactory.getNewStandardObjectMapperWithPureProtocolExtensionSupports();
+
 
     @Override
     public String getName()
@@ -153,14 +161,14 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
         }
     }
 
-    private CompletableFuture<? extends LambdaFunction<?>> compile(SectionState sectionState)
+    private CompletableFuture<Pair<LambdaFunction<?>, Lambda>> compile(SectionState sectionState)
     {
         DocumentState documentState = sectionState.getDocumentState();
         GlobalState globalState = documentState.getGlobalState();
         return globalState.getProperty(documentState.getDocumentId() + COMPILE_RESULT_KEY, () -> tryCompile(sectionState));
     }
 
-    private CompletableFuture<? extends LambdaFunction<?>> tryCompile(SectionState sectionState)
+    private CompletableFuture<Pair<LambdaFunction<?>, Lambda>> tryCompile(SectionState sectionState)
     {
         return this.parse(sectionState).thenApply(x ->
                 {
@@ -170,7 +178,7 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
                     {
                         throw compileResult.getEngineException();
                     }
-                    return HelperValueSpecificationBuilder.buildLambda(x, pureModel.getContext());
+                    return Tuples.<LambdaFunction<?>, Lambda>pair(HelperValueSpecificationBuilder.buildLambda(x, pureModel.getContext()), x);
                 }
                 // when we complete compiling, trigger plan generation on the background to improve user experience...
         ).whenCompleteAsync((l, e) -> this.generatePlan(sectionState), sectionState.getDocumentState().getGlobalState().getForkJoinPool());
@@ -230,10 +238,10 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
     @Override
     public Stream<LegendReference> getLegendReferences(SectionState sectionState)
     {
-        CompletableFuture<? extends LambdaFunction<?>> compiled = this.compile(sectionState);
+        CompletableFuture<Pair<LambdaFunction<?>, Lambda>> compiled = this.compile(sectionState);
         try
         {
-            LambdaFunction<?> lambdaFunction = compiled.get(30, TimeUnit.SECONDS);
+            LambdaFunction<?> lambdaFunction = compiled.get(30, TimeUnit.SECONDS).getOne();
             PureModel pureModel = this.pureGrammarExtension.getCompileResult(sectionState).getPureModel();
             return LegendReferenceResolver.toLegendReference(
                     sectionState,
@@ -267,13 +275,13 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
             return List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, "[]", "Nothing to execute!", section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters));
         }
 
-        Pair<SingleExecutionPlan, PlanExecutionContext> planExecutionContextPair;
+        PlanGenerationResult planGenerationResult;
 
         try
         {
             try
             {
-                planExecutionContextPair = this.generatePlan(section).get(30, TimeUnit.SECONDS);
+                planGenerationResult = this.generatePlan(section).get(30, TimeUnit.SECONDS);
             }
             catch (CompletionException | ExecutionException e)
             {
@@ -289,7 +297,20 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
             return Lists.mutable.with(this.pureGrammarExtension.getExtension().errorResult(e, "Cannot generate an execution plan for given expression.  Likely the expression is not supported yet...", "notebook_cell", section.getDocumentState().getTextLocation()));
         }
 
-        return this.executePlan(section, planExecutionContextPair, inputParameters, requestId);
+        GenericType lambdaReturnType = planGenerationResult.getLambdaFunction()._expressionSequence().getLast()._genericType()._typeArguments().getFirst();
+        if (lambdaReturnType != null && lambdaReturnType._rawType() instanceof RelationType)
+        {
+            try
+            {
+                return List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult("notebook_cell", LegendExecutionResult.Type.SUCCESS, objectMapper.writeValueAsString(planGenerationResult.getLambda()), null, section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters, "cube"));
+            }
+            catch (JsonProcessingException e)
+            {
+                return List.of(FunctionExecutionSupport.FunctionLegendExecutionResult.errorResult(e, e.getMessage(), "notebook_cell", section.getDocumentState().getTextLocation()));
+            }
+        }
+
+        return this.executePlan(section, Tuples.pair(planGenerationResult.getSingleExecutionPlan(), planGenerationResult.getPlanExecutionContext()), inputParameters, requestId);
     }
 
     private MutableList<LegendExecutionResult> executePlan(SectionState section, Pair<SingleExecutionPlan, PlanExecutionContext> planContext, Map<String, Object> inputParameters, CancellationToken requestId)
@@ -321,23 +342,23 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
         }
     }
 
-    private CompletableFuture<Pair<SingleExecutionPlan, PlanExecutionContext>> generatePlan(SectionState sectionState)
+    private CompletableFuture<PlanGenerationResult> generatePlan(SectionState sectionState)
     {
         DocumentState documentState = sectionState.getDocumentState();
         GlobalState globalState = documentState.getGlobalState();
         return globalState.getProperty(documentState.getDocumentId() + PLAN_EXEC_CONTEXT_KEY, () -> tryGeneratePlan(sectionState));
     }
 
-    private CompletableFuture<Pair<SingleExecutionPlan, PlanExecutionContext>> tryGeneratePlan(SectionState sectionState)
+    private CompletableFuture<PlanGenerationResult> tryGeneratePlan(SectionState sectionState)
     {
-        return this.compile(sectionState).thenApplyAsync(lambdaFunction ->
+        return this.compile(sectionState).thenApplyAsync(lambdaFunctionAndLambda ->
         {
             try
             {
                 PureModel pureModel = this.pureGrammarExtension.getCompileResult(sectionState).getPureModel();
                 GlobalState globalState = sectionState.getDocumentState().getGlobalState();
-                SingleExecutionPlan singleExecutionPlan = FunctionExecutionSupport.generateSingleExecutionPlan(pureModel, globalState.getSetting(Constants.LEGEND_PROTOCOL_VERSION), lambdaFunction);
-                return Tuples.pair(singleExecutionPlan, new PlanExecutionContext(singleExecutionPlan, List.of()));
+                SingleExecutionPlan singleExecutionPlan = FunctionExecutionSupport.generateSingleExecutionPlan(pureModel, globalState.getSetting(Constants.LEGEND_PROTOCOL_VERSION), lambdaFunctionAndLambda.getOne());
+                return new PlanGenerationResult(singleExecutionPlan, new PlanExecutionContext(singleExecutionPlan, List.of()), lambdaFunctionAndLambda.getOne(), lambdaFunctionAndLambda.getTwo());
             }
             catch (JavaCompileException e)
             {
@@ -362,6 +383,42 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
         {
             LOGGER.error("Error fetching autocompletion results", e);
             return List.of();
+        }
+    }
+
+    private static class PlanGenerationResult
+    {
+        private final SingleExecutionPlan singleExecutionPlan;
+        private final PlanExecutionContext planExecutionContext;
+        private final LambdaFunction<?> lambdaFunction;
+        private final Lambda lambda;
+
+        public PlanGenerationResult(SingleExecutionPlan singleExecutionPlan, PlanExecutionContext planExecutionContext, LambdaFunction<?> lambdaFunction, Lambda lambda)
+        {
+            this.singleExecutionPlan = singleExecutionPlan;
+            this.planExecutionContext = planExecutionContext;
+            this.lambdaFunction = lambdaFunction;
+            this.lambda = lambda;
+        }
+
+        public SingleExecutionPlan getSingleExecutionPlan()
+        {
+            return singleExecutionPlan;
+        }
+
+        public PlanExecutionContext getPlanExecutionContext()
+        {
+            return planExecutionContext;
+        }
+
+        public LambdaFunction<?> getLambdaFunction()
+        {
+            return lambdaFunction;
+        }
+
+        public Lambda getLambda()
+        {
+            return lambda;
         }
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
@@ -394,26 +394,16 @@ public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
 
     Iterable<? extends LegendExecutionResult> getQueryTypeahead(SectionState section, String entityPath, Map<String, String> executableArgs, Map<String, Object> inputParameters)
     {
-        PureModelContextData pureModelContextData = this.pureGrammarExtension.getCompileResult(section).getPureModelContextData();
+        PureModel pureModel = this.pureGrammarExtension.getCompileResult(section).getPureModel();
         MutableList<LegendExecutionResult> results = Lists.mutable.empty();
 
         try
         {
-            String graphCode = "";
-            if (pureModelContextData != null)
-            {
-                PureModelContextData newData = PureModelContextData.newBuilder()
-                        .withOrigin(pureModelContextData.getOrigin())
-                        .withSerializer(pureModelContextData.getSerializer())
-                        .withElements(ListIterate.select(pureModelContextData.getElements(), el -> !el.getPath().equals(REPL_RUN_FUNCTION_QUALIFIED_PATH)))
-                        .build();
-                graphCode = PureGrammarComposer.newInstance(PureGrammarComposerContext.Builder.newInstance().build()).renderPureModelContextData(newData);
-            }
             String code = executableArgs.get("code");
             Lambda baseQuery = objectMapper.readValue(executableArgs.get("baseQuery"), Lambda.class);
             String baseQueryCode = baseQuery != null ? baseQuery.body.get(0).accept(DEPRECATED_PureGrammarComposerCore.Builder.newInstance().withRenderStyle(RenderStyle.STANDARD).build()) : null;
             String queryCode = (baseQueryCode != null ? baseQueryCode : "") + code;
-            Completer completer = new Completer(graphCode, this.completerExtensions);
+            Completer completer = new Completer(pureModel, this.completerExtensions);
             CompletionResult result = completer.complete(queryCode);
             results.add(FunctionExecutionSupport.FunctionLegendExecutionResult.newResult(entityPath, LegendExecutionResult.Type.SUCCESS,
                 objectMapper.writeValueAsString(result), null, section.getDocumentState().getDocumentId(), section.getSectionNumber(), inputParameters));

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/notebook/PureBookLSPGrammarExtension.java
@@ -22,7 +22,6 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.tuple.Tuples;
-import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.ide.lsp.extension.*;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
 import org.finos.legend.engine.ide.lsp.extension.core.FunctionExecutionSupport;
@@ -41,14 +40,11 @@ import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParserConte
 import org.finos.legend.engine.language.pure.grammar.from.domain.DomainParser;
 import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtensions;
 import org.finos.legend.engine.language.pure.grammar.to.DEPRECATED_PureGrammarComposerCore;
-import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposer;
-import org.finos.legend.engine.language.pure.grammar.to.PureGrammarComposerContext;
 import org.finos.legend.engine.plan.execution.PlanExecutionContext;
 import org.finos.legend.engine.plan.execution.result.Result;
 import org.finos.legend.engine.plan.execution.result.serialization.SerializationFormat;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
-import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.executionPlan.SingleExecutionPlan;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.Lambda;
 import org.finos.legend.engine.repl.autocomplete.Completer;
@@ -74,8 +70,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.finos.legend.engine.repl.shared.ExecutionHelper.REPL_RUN_FUNCTION_QUALIFIED_PATH;
 
 public class PureBookLSPGrammarExtension implements LegendLSPGrammarExtension
 {

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/StateForTestFactory.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/StateForTestFactory.java
@@ -232,6 +232,12 @@ public class StateForTestFactory
     public MutableList<SectionState> newSectionStates(MutableMap<String, String> files)
     {
         TestGlobalState globalState = new TestGlobalState();
+        return newSectionStates(globalState, files);
+    }
+
+    public MutableList<SectionState> newSectionStates(GlobalState gs, MutableMap<String, String> files)
+    {
+        TestGlobalState globalState = (TestGlobalState) gs;
         MutableList<SectionState> sectionStates = Lists.mutable.empty();
         files.forEach((docId, text) ->
         {

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
@@ -259,7 +259,7 @@ public class TestPureBookLSPGrammarExtension
                 "\"startColumn\":43,\"startLine\":1}}],\"parameters\":[],\"sourceInformation\":{\"endColumn\":63," +
                 "\"endLine\":1,\"sourceId\":\"notebook.purebook\",\"startColumn\":1,\"startLine\":1}}";
         Iterable<? extends LegendExecutionResult> actual = this.extension.execute(notebook, "notebook", "executeCell",
-                Map.of("requestId", "123456", "enableDatacube", "true"), Map.of(),
+                Map.of("requestId", "123456", "enableDataCube", "true"), Map.of(),
                 notebook.getDocumentState().getGlobalState().cancellationToken("test"));
 
         Assertions.assertEquals(1, Iterate.sizeOf(actual));

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
@@ -301,10 +301,8 @@ public class TestPureBookLSPGrammarExtension
     @Test
     void cancel()
     {
-        SectionState notebook = stateForTestFactory.newPureBookSectionState("notebook.purebook", "#>{test::h2Store.personTable}#->select()->from(test::h2Runtime)");
-        GlobalState gs = notebook.getDocumentState().getGlobalState();
-        MutableMap<String, String> codeFiles = this.getCodeFilesThatParseCompile();
-        stateForTestFactory.newSectionStates(gs, codeFiles);
+        SectionState pureCode = stateForTestFactory.newSectionState("func.pure", "function hello::world():Any[1]{ 1 + 1 }");
+        SectionState notebook = stateForTestFactory.newPureBookSectionState(pureCode.getDocumentState().getGlobalState(), "notebook.purebook", "hello::world()");
 
         // it's hard to test the cancel,
         // hence we will trigger the cancellation 1st

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.ide.lsp.extension.StateForTestFactory;
 import org.finos.legend.engine.ide.lsp.extension.completion.LegendCompletion;
@@ -163,12 +165,10 @@ public class TestPureBookLSPGrammarExtension
         );
     }
 
-    @Test
-    void relationExecuteCellReturnsLambda()
+    private MutableMap<String, String> getCodeFilesThatParseCompile()
     {
-        SectionState notebook = stateForTestFactory.newPureBookSectionState("notebook.purebook", "#>{test::h2Store.personTable}#->select()->from(test::h2Runtime)");
-        GlobalState gs = notebook.getDocumentState().getGlobalState();
-        stateForTestFactory.newSectionState(gs, "database.pure",
+        MutableMap<String, String> codeFiles = Maps.mutable.empty();
+        codeFiles.put("database.pure",
                 "###Relational\n" +
                         "Database test::h2Store\n" +
                         "(\n" +
@@ -186,7 +186,7 @@ public class TestPureBookLSPGrammarExtension
                         "    )\n" +
                         ")");
 
-        stateForTestFactory.newSectionState(gs, "connection.pure",
+        codeFiles.put("connection.pure",
                 "###Connection\n" +
                         "RelationalDatabaseConnection test::h2Conn\n" +
                         "{\n" +
@@ -199,7 +199,7 @@ public class TestPureBookLSPGrammarExtension
                         "    auth: DefaultH2;\n" +
                         "}");
 
-        stateForTestFactory.newSectionState(gs, "runtime.pure",
+        codeFiles.put("runtime.pure",
                 "###Runtime\n" +
                         "Runtime  test::h2Runtime\n" +
                         "{\n" +
@@ -209,6 +209,16 @@ public class TestPureBookLSPGrammarExtension
                         "        test::h2Conn: [ test::h2Store ]\n" +
                         "    ];\n" +
                         "}");
+        return codeFiles;
+    }
+
+    @Test
+    void relationExecuteCellReturnsLambda()
+    {
+        SectionState notebook = stateForTestFactory.newPureBookSectionState("notebook.purebook", "#>{test::h2Store.personTable}#->select()->from(test::h2Runtime)");
+        GlobalState gs = notebook.getDocumentState().getGlobalState();
+        MutableMap<String, String> codeFiles = this.getCodeFilesThatParseCompile();
+        stateForTestFactory.newSectionStates(gs, codeFiles);
 
         String expectedMessage = "{\"_type\":\"lambda\",\"body\":[{\"_type\":\"func\",\"function\":\"from\"," +
                 "\"parameters\":[{\"_type\":\"func\",\"function\":\"select\"," +

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/notebook/TestPureBookLSPGrammarExtension.java
@@ -233,8 +233,8 @@ public class TestPureBookLSPGrammarExtension
                 "\"sourceInformation\":{\"endColumn\":46,\"endLine\":1,\"sourceId\":\"notebook.purebook\"," +
                 "\"startColumn\":43,\"startLine\":1}}],\"parameters\":[],\"sourceInformation\":{\"endColumn\":63," +
                 "\"endLine\":1,\"sourceId\":\"notebook.purebook\",\"startColumn\":1,\"startLine\":1}}";
-        Iterable<? extends LegendExecutionResult> actual = this.extension.execute(notebook, "notebook", "executeCell"
-                , Map.of("requestId", "123456"), Map.of(),
+        Iterable<? extends LegendExecutionResult> actual = this.extension.execute(notebook, "notebook", "executeCell",
+                Map.of("requestId", "123456"), Map.of(),
                 notebook.getDocumentState().getGlobalState().cancellationToken("test"));
 
         Assertions.assertEquals(1, Iterate.sizeOf(actual));


### PR DESCRIPTION
Add functionality to support DataCube in purebook:
- When executing a cell, if the cell returns a relation type and the `enableDataCube` flag is passed as true, we no longer execute the plan generated. Instead, we just return the lambda object to the client so that the client can use that lambda to initialize a DataCube instance, which will handle executing the query.
- Add a new `getQueryTypeahead` function to support autocomplete when the user is adding extended columns to DataCube