### PR TITLE
Fix bug where convertGrammarToLambdaJsonBatch doesn't return _type property in root object

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
@@ -481,7 +481,7 @@ public interface FunctionExecutionSupport
         try
         {
             Map<String, GrammarAPI.ParserInput> input = objectMapper.readValue(executableArgs.get("input"), new TypeReference<>() {});
-            Map<String, Lambda> result = new UnifiedMap<>();
+            TypedMapLambda result = new TypedMapLambda();
 
             MapAdapter.adapt(input).forEachKeyValue((key, value) -> result.put(key,
                     PureGrammarParser.newInstance().parseLambda(
@@ -858,5 +858,13 @@ public interface FunctionExecutionSupport
         MutableList<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport()));
         MutableList<PlanTransformer> planTransformers = Iterate.flatCollect(ServiceLoader.load(PlanGeneratorExtension.class), PlanGeneratorExtension::getExtraPlanTransformers, Lists.mutable.empty());
         return PlanGenerator.generateExecutionPlan(functionDefinition, null, null, null, pureModel, clientVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
+    }
+
+    // Required so that Jackson properly includes _type for the top level element
+    class TypedMapLambda extends UnifiedMap<String, Lambda>
+    {
+        public TypedMapLambda()
+        {
+        }
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
+++ b/legend-engine-ide-lsp-default-extensions/src/main/java/org/finos/legend/engine/ide/lsp/extension/core/FunctionExecutionSupport.java
@@ -30,7 +30,6 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.map.mutable.MapAdapter;
-import org.eclipse.collections.impl.map.mutable.UnifiedMap;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
@@ -481,7 +480,7 @@ public interface FunctionExecutionSupport
         try
         {
             Map<String, GrammarAPI.ParserInput> input = objectMapper.readValue(executableArgs.get("input"), new TypeReference<>() {});
-            TypedMapLambda result = new TypedMapLambda();
+            Map<String, Lambda> result = org.eclipse.collections.api.factory.Maps.mutable.empty();
 
             MapAdapter.adapt(input).forEachKeyValue((key, value) -> result.put(key,
                     PureGrammarParser.newInstance().parseLambda(
@@ -495,7 +494,7 @@ public interface FunctionExecutionSupport
 
             results.add(FunctionLegendExecutionResult.newResult(entityPath,
                     LegendExecutionResult.Type.SUCCESS,
-                    objectMapper.writeValueAsString(result),
+                    objectMapper.writerFor(new TypeReference<Map<String,Lambda>>() {}).writeValueAsString(result),
                     null,
                     section.getDocumentState().getDocumentId(),
                     section.getSectionNumber(),
@@ -858,13 +857,5 @@ public interface FunctionExecutionSupport
         MutableList<? extends Root_meta_pure_extension_Extension> routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(pureModel.getExecutionSupport()));
         MutableList<PlanTransformer> planTransformers = Iterate.flatCollect(ServiceLoader.load(PlanGeneratorExtension.class), PlanGeneratorExtension::getExtraPlanTransformers, Lists.mutable.empty());
         return PlanGenerator.generateExecutionPlan(functionDefinition, null, null, null, pureModel, clientVersion, PlanPlatform.JAVA, null, routerExtensions, planTransformers);
-    }
-
-    // Required so that Jackson properly includes _type for the top level element
-    class TypedMapLambda extends UnifiedMap<String, Lambda>
-    {
-        public TypedMapLambda()
-        {
-        }
     }
 }

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
@@ -1242,9 +1242,9 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         Map<String, String> executableArgs = Map.of("input", "{\"code1\": {\"value\": \"" + grammar1 + "\", \"returnSourceInformation\": false}," +
                 "\"code2\": {\"value\": \"" + grammar2 + "\", \"returnSourceInformation\": false}}");
 
-        String expected = "{\"code1\":{\"body\":[{\"_type\":\"property\",\"parameters\":[{\"_type\":\"var\"," +
+        String expected = "{\"code1\":{\"_type\":\"lambda\",\"body\":[{\"_type\":\"property\",\"parameters\":[{\"_type\":\"var\"," +
                 "\"name\":\"x\"}],\"property\":\"hireType\"}],\"parameters\":[{\"_type\":\"var\",\"name\":\"x\"}]}," +
-                "\"code2\":{\"body\":[{\"_type\":\"integer\",\"value\":5}],\"parameters\":[{\"_type\":\"var\"," +
+                "\"code2\":{\"_type\":\"lambda\",\"body\":[{\"_type\":\"integer\",\"value\":5}],\"parameters\":[{\"_type\":\"var\"," +
                 "\"name\":\"x\"}]}}";
         Iterable<? extends LegendExecutionResult> actual = testCommand(sectionState, "vscodelsp::test::TestService2", GRAMMAR_TO_JSON_LAMBDA_BATCH_ID, executableArgs);
 


### PR DESCRIPTION
Fix bug where convertGrammarToLambdaJsonBatch doesn't return _type property in root object.

Use local `TypedMapLambda` class so Jackson includes _type.