### PR TITLE
Download file on server when user exports data

### DIFF
--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
@@ -1248,21 +1248,21 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         RuntimePointer runtime = new RuntimePointer();
         runtime.runtime = "vscodelsp::test::H2RuntimeRelational";
         ExecutionContext context = new BaseExecutionContext();
-        String filePath = tempDir.resolve("result.csv").toString();
+        String exportFilePath = tempDir.resolve("result.csv").toString();
         Map<String, String> executableArgs = Map.of("lambda", objectMapper.writeValueAsString(lambda), "mapping",
                 "vscodelsp::test::EmployeeRelationalMapping", "runtime", objectMapper.writeValueAsString(runtime),
                 "context", objectMapper.writeValueAsString(context), "serializationFormat", "CSV",
-                "filePath", filePath);
+                "exportFilePath", exportFilePath);
         Map<String, Object> inputParameters = Map.of("testParam", "testValue");
 
         Iterable<? extends LegendExecutionResult> actual = testCommand(sectionState, "vscodelsp::test::TestService2",
-                EXPORT_DATA_ID, executableArgs, inputParameters);
+                EXECUTE_QUERY_ID, executableArgs, inputParameters);
 
         // Check that expected result is returned
         Assertions.assertEquals(1, Iterate.sizeOf(actual));
         FunctionLegendExecutionResult result = (FunctionLegendExecutionResult) actual.iterator().next();
         Assertions.assertEquals(LegendExecutionResult.Type.SUCCESS, result.getType(), result.getMessage());
-        Assertions.assertEquals(result.getMessage(), tempDir.resolve("result.csv").toString());
+        Assertions.assertEquals(result.getMessage(), exportFilePath);
 
         // Check that expected data is written to file
         try (BufferedReader buffer = new BufferedReader(new InputStreamReader(new FileInputStream(tempDir.resolve("result.csv").toFile()))))

--- a/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
+++ b/legend-engine-ide-lsp-default-extensions/src/test/java/org/finos/legend/engine/ide/lsp/extension/service/TestServiceLSPGrammarExtension.java
@@ -358,8 +358,8 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
                         "    execution : Single\n" +
                         "    {\n" +
                         "        query : testParam: String[1]|vscodelsp::test::EmployeeRelational.all()->project(\n" +
-                        "                  [ x|$x.firstName ],\n" +
-                        "                  [ 'First Name' ]\n" +
+                        "                  [ x|$x.id, x|$x.firstName ],\n" +
+                        "                  [ 'ID', 'First Name' ]\n" +
                         "        );\n" +
                         "        mapping : vscodelsp::test::EmployeeRelationalMapping;\n" +
                         "        runtime : vscodelsp::test::H2RuntimeRelational;\n" +
@@ -1067,10 +1067,8 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         FunctionLegendExecutionResult result = (FunctionLegendExecutionResult) actual.iterator().next();
         Assertions.assertEquals(LegendExecutionResult.Type.SUCCESS, result.getType(), result.getMessage());
         Assertions.assertEquals("testValue", result.getInputParameters().get("testParam"));
-        Assertions.assertTrue(result.getMessage().contains("\"columns\":[{\"name\":\"First Name\"," +
-                "\"type\":\"String\",\"relationalType\":\"VARCHAR(200)\"}]}"));
-        Assertions.assertTrue(result.getMessage().contains("\"result\" : {\"columns\" : [\"First Name\"], \"rows\" : " +
-                "[{\"values\": [\"Doe\"]}]}"));
+        Assertions.assertTrue(result.getMessage().contains("\"columns\":[{\"name\":\"ID\",\"type\":\"Integer\",\"relationalType\":\"INTEGER\"},{\"name\":\"First Name\",\"type\":\"String\",\"relationalType\":\"VARCHAR(200)\"}]}"));
+        Assertions.assertTrue(result.getMessage().contains("\"result\" : {\"columns\" : [\"ID\",\"First Name\"], \"rows\" : [{\"values\": [1,\"Doe\"]}]}"));
     }
 
     @Test
@@ -1270,7 +1268,7 @@ public class TestServiceLSPGrammarExtension extends AbstractLSPGrammarExtensionT
         try (BufferedReader buffer = new BufferedReader(new InputStreamReader(new FileInputStream(tempDir.resolve("result.csv").toFile()))))
         {
             String actualFileContent = buffer.lines().collect(Collectors.joining("\n"));
-            Assertions.assertEquals(actualFileContent, "First Name\nDoe");
+            Assertions.assertEquals(actualFileContent, "ID,First Name\n1,Doe");
         }
         catch (IOException e)
         {


### PR DESCRIPTION
Download the file on the LSP server when the user exports data rather than returning the query result to the client for it to resolve.

This will improve performance for large query results because we won't need to send the entire large result back to the client for it to download.